### PR TITLE
Fix pressure calibration geometry scaling when extrusion width is absolute

### DIFF
--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -1224,7 +1224,7 @@ double CalibrationPressureAdvDialog::magical_scaling(double nozzle_diameter, dou
 double CalibrationPressureAdvDialog::magical_scaling(double nozzle_diameter, double er_width, double filament_max_overlap, double perimeter_overlap, double external_perimeter_overlap, double base_layer_height, double er_spacing) {
 
     const DynamicPrintConfig* print_config = this->gui_app->get_tab(Preset::TYPE_FFF_PRINT)->get_config();//i should pass this over instead...
-    assert(er_width > 1.0 && "er_width should be above 1.0 as it's a percentage value");
+    (void)print_config;
 
     // extrusions 1 and 2 overlap with external and internal perimeter overlap/spacing values. (same for extrusions 3 and 4)
     // extrusions 2 and 3 would normally have internal infill but the 90_bend model is scaled so the 2/3 are touching and won't have a 'gap' that could be filled.
@@ -1234,7 +1234,11 @@ double CalibrationPressureAdvDialog::magical_scaling(double nozzle_diameter, dou
     //                                        [ curved cap ] ---flat--- [ curved cap ]                                     [ curved cap ] ---flat--- [ curved cap ]
 
     //this can obviously be cleaned up alot... kept it all expanded since i'm not sure if there SHOULD be a gap/overlap between extrusions 2/3
-    double extrusion_width = nozzle_diameter * (er_width / 100.0);
+    // er_width is currently collected with get_abs_value(), so it is already expressed in mm.
+    // Keep a fallback for any legacy callsites still passing percentages.
+    double extrusion_width = er_width;
+    if (er_width > nozzle_diameter * 3.0)
+        extrusion_width = nozzle_diameter * (er_width / 100.0);
     double model_design_width = nozzle_diameter * 4.0;
     double raw_wall_width = extrusion_width * 4;
     double overgap_value = extrusion_width - er_spacing;


### PR DESCRIPTION
### Motivation

- The Pressure-Advance (PA) calibration generator produced malformed/near-line geometry because `er_width` was interpreted as a percentage and scaled down even though callers now supply an absolute extrusion width via `get_abs_value()`.

### Description

- Update `CalibrationPressureAdvDialog::magical_scaling()` to treat `er_width` as an absolute width in millimeters and keep a compatibility fallback for legacy percentage-style values, by computing `extrusion_width` from `er_width` unless `er_width` is clearly a percent-like value. (`src/slic3r/GUI/CalibrationPressureAdvDialog.cpp`)
- Remove the invalid assertion that assumed `er_width` is always a percentage and mark the now-unused `print_config` reference as intentionally unused to avoid warnings.

### Testing

- Ran static patch/format checks with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f6f22980832d9d878c50239dabb0)