### PR TITLE
Klipper-only pressure-advance sane-max clamp; rename/clarify pressure calibration UI and docs

### DIFF
--- a/resources/calibration/filament_pressure/filament_pressure.html
+++ b/resources/calibration/filament_pressure/filament_pressure.html
@@ -51,23 +51,23 @@
 </tbody>
 </table>
 
-<p><span style="color: red; font-weight: bold;">This test is still in development. The beta version should work well, but your current print settings need to be saved before clicking "Generate" since they are used to create the model.</span></p>
+<p><span style="color: red; font-weight: bold;">This line pressure advance calibration is still in development. The beta version should work well, but your current print settings need to be saved before clicking "Generate" since they are used to create the model.</span></p>
 
-<p>Note: This test will automatically pull all your currently saved configuration parameters and generate a model for you to print. For optimal results, depending if you're chasing speed/quality or a mix of both, it is recommended to keep similar speeds for most extrusion roles, (although this is not mandatory).</p>
+<p>Note: This calibration will automatically pull all your currently saved configuration parameters and generate a model for you to print. For optimal results, depending if you're chasing speed/quality or a mix of both, it is recommended to keep similar speeds for most extrusion roles, (although this is not mandatory).</p>
 
 <h2>How to Tune Your Printer for Pressure/Linear Advance</h2>
 <p>To get started:</p>
 <ul>
-<li>Select the number of tests to create, the <b>max</b> is <b>10</b>.</li>
+<li>Select the number of calibration lines to create, the <b>max</b> is <b>10</b>.</li>
 <li>Each row represents the config parameters for the selected extrusion role (e.g., first row = ExternalPerimeter, second row = FirstLayer).</li>
 <li>Select the start/end and increment values, <b>you can manually edit these values if you want larger or smaller values.</b></li>
-<li>Since each model will have its own config, one test model might print faster or slower than others. This is expected and normal.</li>
+<li>Since each model will have its own config, one calibration model might print faster or slower than others. This is expected and normal.</li>
 <li>This is the first calibration tool that supports <b>Arachne!</b> so leave it enabled if you use Arachne. </li>
-<li>Helpful tip: If you are running multiple tests on a single plate, take a screenshot of the main configuration page (or leave it open and drag the window out of the way) to match the row number to the ID label on the bottom right of the loaded model. (counting starts at '0' ☺)<br>
+<li>Helpful tip: If you are running multiple calibration lines on a single plate, take a screenshot of the main configuration page (or leave it open and drag the window out of the way) to match the row number to the ID label on the bottom right of the loaded model. (counting starts at '0' ☺)<br>
 You can also inspect each 'base model' and view the object modifiers for each 90° bend model, the 'region_gcode' will have a comment for the extrusion role.<br></li>
 </ul>
 
-<li>if you use PA/LA commands in your <b>feature_gcode</b> you need to remove it, otherwise your test will be invalidated.</li>
+<li>If you use PA/LA commands in your <b>feature_gcode</b> you need to remove them, otherwise your calibration will be invalid.</li>
 
 <p>Currently unsupported roles:</p>
 <ul>

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7560,16 +7560,25 @@ std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const Extrus
         if (pa < 0) {
             pa = 0;
         }
-        // If the resolved PA exceeds the sane maximum, a per-role override (or
-        // the base value itself) is being used as an informal "disabled" sentinel
-        // (e.g., 100 meaning "don't override"). Fall back to the base PA if it is
-        // valid; otherwise disable PA for this path to prevent firmware crashes.
-        if (pa > PA_SANE_MAX) {
-            BOOST_LOG_TRIVIAL(warning) << "PA value " << pa
-                << " for role " << gcode_extrusion_role_to_string(extrusion_role_to_gcode_extrusion_role(path.role()))
-                << " exceeds " << PA_SANE_MAX << ". Treating as disabled sentinel; "
-                << "use the toggle (!) in filament settings to properly disable per-role PA.";
+        // Only Klipper needs PA sanity clamping here: extreme values can crash
+        // its MCU planner. Other firmwares may intentionally use larger values
+        // (e.g. Marlin M900 K) and should keep the user-configured value.
+        if (pa > PA_SANE_MAX && m_config.gcode_flavor.value == gcfKlipper) {
+            const std::string role = gcode_extrusion_role_to_string(extrusion_role_to_gcode_extrusion_role(path.role()));
+            const double      role_pa_original = pa;
             pa = (base_pa <= PA_SANE_MAX) ? base_pa : 0.0;
+
+            // Keep warning only for truly invalid Klipper values (resolved PA and
+            // base PA both out of range), but include flavor and role/value context.
+            if (base_pa > PA_SANE_MAX) {
+                BOOST_LOG_TRIVIAL(warning)
+                    << "Invalid pressure advance for flavor=klipper"
+                    << ", role=" << role
+                    << ", role_pa_original=" << role_pa_original
+                    << ", base_pa=" << base_pa
+                    << " (limit " << PA_SANE_MAX << ")."
+                    << " Falling back to 0 to prevent unsafe G-code emission.";
+            }
         }
     }
     return { pa, travel_pa };

--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -207,7 +207,7 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
 
     Plater* plat = this->main_frame->plater();
     Model& model = plat->model();
-    if (!plat->new_project(L("Pressure calibration")))
+    if (!plat->new_project(L("Pressure advance line calibration")))
         return;
 
     bool autocenter = gui_app->app_config->get("autocenter") == "1";
@@ -873,7 +873,7 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         gcfNoExtrusion*/
 
         // Name each tower so they're identifiable on the build plate and in the object list
-        model.objects[objs_idx[id_item]]->name = "PA Test " + std::to_string(id_item) + " - " + selected_extrusion_role;
+        model.objects[objs_idx[id_item]]->name = "PA Line Calibration " + std::to_string(id_item) + " - " + selected_extrusion_role;
 
         // config modifers for the base model
         model.objects[objs_idx[id_item]]->config.set_key_value("bottom_fill_pattern", new ConfigOptionEnum<InfillPattern>(ipMonotonic));// ipConcentric or ipConcentricGapFill ?
@@ -1305,11 +1305,11 @@ void CalibrationPressureAdvDialog::create_buttons(wxStdDialogButtonSizer* button
 
         wxString number_of_runs[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" };//setting this any higher will break loading the model for the ID
         nbRuns = new wxComboBox(mainPanel, wxID_ANY, wxString{ "1" }, wxDefaultPosition, wxDefaultSize, 10, number_of_runs, wxCB_READONLY);
-        nbRuns->SetToolTip(_L("Select the number of tests to generate, max 6 is recommended due to bed size limits"));
+        nbRuns->SetToolTip(_L("Select the number of calibration lines to generate. Max 6 is recommended due to bed size limits."));
         nbRuns->SetSelection(0);
         nbRuns->Bind(wxEVT_COMBOBOX, &CalibrationPressureAdvDialog::on_row_change, this);
 
-        wxStaticText* text_generate_count = new wxStaticText(mainPanel, wxID_ANY, _L("Number of" + prefix + "tests: "));
+        wxStaticText* text_generate_count = new wxStaticText(mainPanel, wxID_ANY, _L("Number of" + prefix + "calibration lines: "));
         text_generate_count->SetForegroundColour(text_color);
         commonSizer->Add(text_generate_count, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
         commonSizer->Add(nbRuns, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);

--- a/tests/fff_print/test_gcode.cpp
+++ b/tests/fff_print/test_gcode.cpp
@@ -203,6 +203,33 @@ TEST_CASE("Used filament", "[GCode]") {
     CHECK(print.print_statistics().total_used_filament > 0);
 }
 
+TEST_CASE("Pressure advance sane-max fallback is Klipper-only", "[GCode]") {
+    SECTION("Marlin keeps configured PA above sane max") {
+        DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+        config.set_deserialize_strict({
+            { "gcode_flavor", "marlin2" },
+            { "start_gcode", "" },
+            { "filament_pressure_advance", "3" },
+        });
+
+        const std::string gcode = Slic3r::Test::slice({ TestMesh::cube_20x20x20 }, config);
+        CHECK(gcode.find("M900 K3") != std::string::npos);
+    }
+
+    SECTION("Klipper still safely falls back for extreme PA") {
+        DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+        config.set_deserialize_strict({
+            { "gcode_flavor", "klipper" },
+            { "start_gcode", "" },
+            { "filament_pressure_advance", "100" },
+        });
+
+        const std::string gcode = Slic3r::Test::slice({ TestMesh::cube_20x20x20 }, config);
+        CHECK(gcode.find("SET_PRESSURE_ADVANCE ADVANCE=0") != std::string::npos);
+        CHECK(gcode.find("SET_PRESSURE_ADVANCE ADVANCE=100") == std::string::npos);
+    }
+}
+
 void check_m73s(Print& print){
     std::vector<double> percent{};
     bool got_100 = false;


### PR DESCRIPTION
### Motivation

- Prevent unsafe G-code emission that can crash Klipper's MCU planner by clamping extreme pressure-advance (PA) values only for Klipper while preserving user-configured values for other firmwares. 
- Clarify UI text and documentation to reflect the tool produces calibration "lines" and to improve naming/labels for the pressure advance calibration workflow. 

### Description

- Change PA handling in `src/libslic3r/GCode.cpp` to only apply the `PA_SANE_MAX` fallback when `gcode_flavor == gcfKlipper`, and fall back to `base_pa` or `0.0` as appropriate. 
- Improve warning output to include flavor, role, the original resolved role PA and base PA, and only emit the warning when both resolved PA and base PA exceed `PA_SANE_MAX`. 
- Update UI labels and tooltips in `src/slic3r/GUI/CalibrationPressureAdvDialog.cpp` to use phrasing like "Pressure advance line calibration", update model naming to "PA Line Calibration", and adjust combo tooltip/label text to reference "calibration lines". 
- Edit copy in `resources/calibration/filament_pressure/filament_pressure.html` to replace ambiguous wording (e.g. "test") with clearer "calibration/line" phrasing and to improve several informational sentences. 
- Add a unit test in `tests/fff_print/test_gcode.cpp` (`Pressure advance sane-max fallback is Klipper-only`) that verifies Marlin preserves configured PA above the sane max while Klipper falls back to safe values. 

### Testing

- Added and ran the unit test `Pressure advance sane-max fallback is Klipper-only` in `tests/fff_print/test_gcode.cpp`, and it passed. 
- Ran the `tests/fff_print` test set including existing GCode tests after changes, and all tests completed successfully. 
- Verified that the UI strings and resource HTML changes compile and the calibration dialog can generate the expected number of models in a local build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f3b77494832d95b6366aa74ef02f)