### PR TITLE
Make pressure-advance sane-max guard firmware-aware

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7571,7 +7571,8 @@ std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const Extrus
                 << " exceeds Klipper maximum " << PA_SANE_MAX << ". "
                 << "Treating as disabled sentinel for Klipper; "
                 << "use the toggle (!) in filament settings to properly disable per-role PA.";
-            pa = (base_pa <= PA_SANE_MAX) ? base_pa : 0.0;
+            const double fallback_pa = std::clamp(base_pa, 0.0, PA_SANE_MAX);
+            pa = fallback_pa;
         }
     }
     return { pa, travel_pa };

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7560,19 +7560,26 @@ std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const Extrus
         if (pa < 0) {
             pa = 0;
         }
-        // Klipper's planner cannot handle very large PA values. If the resolved
-        // PA exceeds the sane maximum, a per-role override (or the base value
-        // itself) is likely used as an informal "disabled" sentinel (e.g., 100
-        // meaning "don't override"). Fall back to the base PA if it is valid;
-        // otherwise disable PA for this path to prevent firmware crashes.
+        // Only Klipper needs PA sanity clamping here: extreme values can crash
+        // its MCU planner. Other firmwares may intentionally use larger values
+        // and should keep the user-configured value.
         if (requires_pa_sane_max && pa > PA_SANE_MAX) {
-            BOOST_LOG_TRIVIAL(warning) << "PA value " << pa
-                << " for role " << gcode_extrusion_role_to_string(extrusion_role_to_gcode_extrusion_role(path.role()))
-                << " exceeds Klipper maximum " << PA_SANE_MAX << ". "
-                << "Treating as disabled sentinel for Klipper; "
-                << "use the toggle (!) in filament settings to properly disable per-role PA.";
-            const double fallback_pa = std::clamp(base_pa, 0.0, PA_SANE_MAX);
-            pa = fallback_pa;
+            const std::string role = gcode_extrusion_role_to_string(extrusion_role_to_gcode_extrusion_role(path.role()));
+            const double role_pa_original = pa;
+            pa = (base_pa >= 0.0 && base_pa <= PA_SANE_MAX) ? base_pa : 0.0;
+
+            // Warn only when both the resolved PA and base PA are invalid for
+            // Klipper. If the base value is valid, a per-role sentinel override
+            // was likely used intentionally and no warning is needed.
+            if (base_pa < 0.0 || base_pa > PA_SANE_MAX) {
+                BOOST_LOG_TRIVIAL(warning)
+                    << "Invalid pressure advance for flavor=klipper"
+                    << ", role=" << role
+                    << ", role_pa_original=" << role_pa_original
+                    << ", base_pa=" << base_pa
+                    << " (limit " << PA_SANE_MAX << ")."
+                    << " Falling back to 0 to prevent unsafe G-code emission.";
+            }
         }
     }
     return { pa, travel_pa };

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7466,11 +7466,11 @@ std::string GCodeGenerator::_travel_before_extrude(const ExtrusionPath &path, co
 
 std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const ExtrusionPath &path) {
 
-    // Maximum PA value we will emit. Values above this cannot be physically
-    // meaningful (2 seconds of lookahead is already extreme) and will crash
-    // Klipper's MCU planner. Users sometimes store values like 100 in per-role
-    // PA fields as an informal "disabled" sentinel; this threshold catches them.
+    // Maximum PA value we will emit when the active firmware requires it.
+    // Values above this can crash Klipper's MCU planner.
     static constexpr double PA_SANE_MAX = 2.0;
+    const GCodeFlavor flavor = config().gcode_flavor.value;
+    const bool requires_pa_sane_max = (flavor == gcfKlipper);
 
     double pa = 0;
     double travel_pa = -1;
@@ -7480,7 +7480,7 @@ std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const Extrus
 
         if (m_config.filament_travel_pa.is_enabled(m_writer.tool()->id())) {
             travel_pa = m_config.filament_travel_pa.get_at(m_writer.tool()->id());
-            if (travel_pa > PA_SANE_MAX)
+            if (requires_pa_sane_max && travel_pa > PA_SANE_MAX)
                 travel_pa = -1;  // treat as disabled sentinel, suppress
         }
         switch (extrusion_role_to_gcode_extrusion_role(path.role())) {
@@ -7560,14 +7560,16 @@ std::pair<double, double> GCodeGenerator::_compute_pressure_advance(const Extrus
         if (pa < 0) {
             pa = 0;
         }
-        // If the resolved PA exceeds the sane maximum, a per-role override (or
-        // the base value itself) is being used as an informal "disabled" sentinel
-        // (e.g., 100 meaning "don't override"). Fall back to the base PA if it is
-        // valid; otherwise disable PA for this path to prevent firmware crashes.
-        if (pa > PA_SANE_MAX) {
+        // Klipper's planner cannot handle very large PA values. If the resolved
+        // PA exceeds the sane maximum, a per-role override (or the base value
+        // itself) is likely used as an informal "disabled" sentinel (e.g., 100
+        // meaning "don't override"). Fall back to the base PA if it is valid;
+        // otherwise disable PA for this path to prevent firmware crashes.
+        if (requires_pa_sane_max && pa > PA_SANE_MAX) {
             BOOST_LOG_TRIVIAL(warning) << "PA value " << pa
                 << " for role " << gcode_extrusion_role_to_string(extrusion_role_to_gcode_extrusion_role(path.role()))
-                << " exceeds " << PA_SANE_MAX << ". Treating as disabled sentinel; "
+                << " exceeds Klipper maximum " << PA_SANE_MAX << ". "
+                << "Treating as disabled sentinel for Klipper; "
                 << "use the toggle (!) in filament settings to properly disable per-role PA.";
             pa = (base_pa <= PA_SANE_MAX) ? base_pa : 0.0;
         }


### PR DESCRIPTION
### Motivation
- Prevent valid Marlin/RepRap/Sprinter `pressure_advance` values from being incorrectly clamped or warned about by making the `PA_SANE_MAX` cap only apply where firmware requires it. 
- Avoid Klipper crashes caused by extremely large PA values while preserving user-intended sentinel behavior for Klipper.

### Description
- Read the active `gcode_flavor` via `config().gcode_flavor.value` and compute `requires_pa_sane_max` (true for `gcfKlipper`) inside `GCodeGenerator::_compute_pressure_advance` in `src/libslic3r/GCode.cpp`.
- Apply the `PA_SANE_MAX` (`2.0`) upper-bound logic only when `requires_pa_sane_max` is true, so non-Klipper flavors keep their configured `pa`/`travel_pa` values (except for the existing `pa < 0 => 0` validation which is unchanged).
- Restrict suppression of `travel_pa` when `> PA_SANE_MAX` to Klipper-only.
- Update the warning message to explicitly reference Klipper and the Klipper maximum to avoid misleading warnings for other firmware flavors.

### Testing
- Applied the patch successfully with `apply_patch` and committed it (`git commit`) which completed without errors.
- Inspected the resulting diff with `git diff -- src/libslic3r/GCode.cpp` and verified the intended changes were present.
- Viewed the modified source region with `nl -ba src/libslic3r/GCode.cpp | sed -n '7464,7585p'` to confirm logic and message updates.
- No full build or unit-test run was performed in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f3b61120832d9271048473c9a16d)