### PR TITLE
Make DBus optional for non-GUI builds and robustly execute post-processing scripts without shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,8 +254,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
 
-    find_package(DBus REQUIRED)
-    include_directories(${DBUS_INCLUDE_DIRS})
+    if (SLIC3R_GUI)
+        find_package(DBus REQUIRED)
+        include_directories(${DBUS_INCLUDE_DIRS})
+    endif ()
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUXX)
@@ -730,4 +732,3 @@ if (NOT WIN32)
 endif()
 
 include(CPack)
-

--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -15,6 +15,7 @@
 #include <boost/nowide/convert.hpp>
 #include <boost/nowide/cenv.hpp>
 #include <boost/nowide/fstream.hpp>
+#include <boost/program_options/parsers.hpp>
 
 #include <cstdlib>   // getenv()
 #ifdef WIN32
@@ -179,57 +180,52 @@ namespace process = boost::process;
 
 static int run_script(const std::string &script, const std::string &gcode, std::string &std_err)
 {
-    // Try to obtain user's default shell
-    const char* shell = ::getenv("SHELL");
-    if (shell == nullptr) { shell = "/bin/sh"; }
+    std::vector<std::string> tokens = boost::program_options::split_unix(script);
+    if (tokens.empty())
+        throw Slic3r::RuntimeError("Post-processing script command is empty.");
 
-    // Quote and escape the gcode path argument
-    std::string command_line;
-    size_t first_space = script.find(' ');
     bool need_absolute_path = false;
-    const std::string command = (std::string::npos != first_space) ? script.substr(0, first_space) : script;
-    const std::string args = (std::string::npos != first_space) ? script.substr(first_space) : "";
-    if (boost::iends_with(command, L".pl")) {
+    const std::string command = tokens.front();
+
+    std::string executable;
+    std::vector<std::string> args;
+    if (boost::iends_with(command, ".pl")) {
         BOOST_LOG_TRIVIAL(trace) << boost::format("Executing script : detecting perl script");
-        // This is a perl script. Run it through the perl interpreter.
-        command_line = "perl ";
+        executable = "perl";
         need_absolute_path = true;
-    } else if (boost::iends_with(command, L".py")) {
+    } else if (boost::iends_with(command, ".py")) {
         BOOST_LOG_TRIVIAL(trace) << boost::format("Executing script : detecting python script");
-        // This is a python script. Run it through the python interpreter.
-        command_line = "python3 ";
+        executable = "python3";
         need_absolute_path = true;
     }
 
     std::string absolute_command_path;
 
-    //check if it's an exe/command (ie it doesn't have an extension)
+    // check if it's an exe/command (ie it doesn't have an extension)
     if (!need_absolute_path && command.find('.') != std::string::npos) {
         // command: it may come from the path, don't check.
         absolute_command_path = command;
     } else {
-        //try to find the file, in different directories
+        // try to find the file, in different directories
         absolute_command_path = Slic3r::find_full_path(boost::filesystem::path(command)).generic_string();
         if (absolute_command_path.empty()) {
-            if (need_absolute_path) {
+            if (need_absolute_path)
                 BOOST_LOG_TRIVIAL(warning) << "The configured post-processing script may not exist: " << command;
-            }
             absolute_command_path = command;
         }
     }
-    command_line += absolute_command_path;
-    command_line += args;
 
-    command_line.append(" '");
-    for (char c : gcode) {
-        if (c == '\'') { command_line.append("'\\''"); }
-        else { command_line.push_back(c); }
-    }
-    command_line.push_back('\'');
+    if (executable.empty())
+        executable = absolute_command_path;
+    else
+        args.push_back(absolute_command_path);
 
-    BOOST_LOG_TRIVIAL(trace) << boost::format("Executing script, shell: %1%, command: %2%") % shell % command_line;
+    args.insert(args.end(), tokens.begin() + 1, tokens.end());
+    args.push_back(gcode);
+
+    BOOST_LOG_TRIVIAL(trace) << boost::format("Executing script, executable: %1%, argc: %2%") % executable % args.size();
     process::ipstream istd_err;
-    process::child child(shell, "-c", command_line, process::std_err > istd_err);
+    process::child child(executable, process::args(args), process::std_err > istd_err);
 
     std_err.clear();
     std::string line;


### PR DESCRIPTION
### Motivation
- Avoid requiring DBus when building headless/non-GUI targets on Linux to simplify minimal builds and CI image creation.
- Improve robustness and security of running post-processing scripts by removing shell interpolation/quoting and using direct exec with argument tokenization.

### Description
- Wrap `find_package(DBus)` and `include_directories(${DBUS_INCLUDE_DIRS})` in `CMakeLists.txt` with `if (SLIC3R_GUI)` so DBus is only required for GUI builds on Linux.
- Use `boost::program_options::split_unix` to tokenize the configured post-processing `script` in `PostProcessor.cpp` and validate it's non-empty, throwing a `RuntimeError` if it is empty.
- Detect interpreter-based scripts (`.pl`, `.py`) and set `executable` to `perl` or `python3` while treating the script path as the first argument when appropriate.
- Resolve the absolute command path via `Slic3r::find_full_path`, assemble an `args` vector including additional tokens and the `gcode` path, and launch the process with `boost::process::child(executable, process::args(args), ...)` instead of executing via the shell.
- Remove manual shell quoting and reliance on the `SHELL` environment variable, and update logging to report the executable and argument count.
- Add `#include <boost/program_options/parsers.hpp>` for tokenization support.

### Testing
- Ran CMake configure and built the project on Linux with `cmake` and `make -j`; the build completed successfully.
- Executed the existing automated test suite with `ctest`, and the tests ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fa4c2320832d810f826985d7280c)