### PR TITLE
Handle vendor bundle fetch failures without crashing

### DIFF
--- a/src/platform/download_vendor_bundles.py
+++ b/src/platform/download_vendor_bundles.py
@@ -22,23 +22,36 @@ if not os.path.exists(out_resources):
 
 for url in all_repositories:
 	print(f"Cloning {url}...")
+	repo_name_with_git = os.path.basename(url)
+	repo_name = repo_name_with_git.removesuffix('.git')
 	try:
 		subprocess.run(["git", "clone", url], check=True)
 	except subprocess.CalledProcessError as e:
 		print(f"Failed to clone {url}: {e}")
-	repo_name_with_git = os.path.basename(url) 
-	repo_name = repo_name_with_git.removesuffix('.git')
+		continue
+
+	description_path = repo_name + "/description.ini"
+	if not os.path.exists(description_path):
+		print(f"Failed to process {url}: missing {description_path}")
+		continue
 		
 	# get id
 	config = configparser.ConfigParser()
-	with open(repo_name+"/description.ini", "r", encoding="utf-8") as f:
+	with open(description_path, "r", encoding="utf-8") as f:
 		config.read_file(f)
 	vendor_id = config.get("vendor", "id")
 	print(f"Vendor ID: {vendor_id}")
+
+	vendor_ini_source = repo_name + "/profiles/" + vendor_id + ".ini"
+	vendor_dir_source = repo_name + "/profiles/" + vendor_id
+	if not os.path.exists(vendor_ini_source) or not os.path.exists(vendor_dir_source):
+		print(f"Failed to process {url}: missing profile files for vendor '{vendor_id}'")
+		continue
+
 	# copy into our resources
-	shutil.copy(repo_name + "/profiles/"+vendor_id+".ini", out_resources+"/profiles/"+vendor_id+".ini");
+	shutil.copy(vendor_ini_source, out_resources+"/profiles/"+vendor_id+".ini");
 	#copy the icon directory
 	if os.path.exists(out_resources+"/profiles/"+vendor_id):
 		shutil.rmtree(out_resources+"/profiles/"+vendor_id)
-	shutil.copytree(repo_name + "/profiles/"+vendor_id, out_resources+"/profiles/"+vendor_id)
+	shutil.copytree(vendor_dir_source, out_resources+"/profiles/"+vendor_id)
 	


### PR DESCRIPTION
### Motivation
- The vendor bundle downloader continued processing after a failed `git clone` and then attempted to read files from a non-existent repo, causing uncaught file-not-found errors. 
- Make the script resilient to partial network failures or malformed vendor repositories so a single bad source does not abort the entire run.

### Description
- Compute `repo_name` from the repo URL earlier and `continue` the loop on `git clone` failure to avoid processing missing directories. 
- Add an explicit existence check for `description.ini` and `continue` if it is missing, to avoid attempting to read a non-existent file. 
- Validate that `profiles/<vendor>.ini` and `profiles/<vendor>/` exist before copying and `continue` if they are missing. 
- Use `vendor_ini_source` and `vendor_dir_source` variables for copy operations to make the logic clearer and safer.

### Testing
- Ran `python3 -m py_compile src/platform/download_vendor_bundles.py` which succeeded. 
- Ran `python3 src/platform/download_vendor_bundles.py` which exercised the usage/argument handling path and produced the expected usage message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a205ebd65c832d9b141ac72edb8924)