### PR TITLE
Add calibration style selector to Pressure Advance dialog and persist style state

### DIFF
--- a/resources/calibration/filament_pressure/filament_pressure.html
+++ b/resources/calibration/filament_pressure/filament_pressure.html
@@ -59,6 +59,12 @@
 <p>To get started:</p>
 <ul>
 <li>Select the number of calibration lines to create, the <b>max</b> is <b>10</b>.</li>
+<li>Select a calibration style:
+  <ul>
+    <li><b>Segmented line sweep (recommended):</b> Uses segmented layer-range configuration that is currently stable and safe for repeated generation/plate clearing.</li>
+    <li><b>Classic line sweep:</b> Matches Orca-style naming but is temporarily disabled while object cleanup handling is fixed for this dialog.</li>
+  </ul>
+</li>
 <li>Each row represents the config parameters for the selected extrusion role (e.g., first row = ExternalPerimeter, second row = FirstLayer).</li>
 <li>Select the start/end and increment values, <b>you can manually edit these values if you want larger or smaller values.</b></li>
 <li>Since each model will have its own config, one calibration model might print faster or slower than others. This is expected and normal.</li>
@@ -80,6 +86,7 @@ However, it currently doesn't work perfectly. Occasionally the models get 'gap f
 
 <h2>Known Bugs</h2>
 <ul>
+<li>Classic line sweep style is visible in the UI for reference, but currently disabled due to a known model/object-list cleanup issue.</li>
 <li>Setting the first layer's PA value for multiple tests only applies the last row's value to (before_layer_gcode).</li>
 <li>The first layer may receive gap fill on the 90° bend models; it is recommended to disable gap fill in the object modifiers if this occurs.</li>
 <li>Occasionally some numbers might get scaled wrong so they won't show up on the G-code preview, this has primarily been for number '1'. If this happens, adjust main config 'thin_perimeters' to '-1'.</li>

--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -12,6 +12,7 @@
 #include <wx/scrolwin.h>
 #include <wx/display.h>
 #include <wx/file.h>
+#include <wx/choice.h>
 #include "wxExtensions.hpp"
 #include "Jobs/ArrangeJob.hpp"
 //#include "Jobs/job.hpp" 2.7 requirement?
@@ -892,9 +893,10 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         model.objects[objs_idx[id_item]]->config.set_key_value("top_solid_layers", new ConfigOptionInt(0));
         model.objects[objs_idx[id_item]]->config.set_key_value("region_gcode", new ConfigOptionString(region_prefix + " \n" ));
 
-        int style = 2;
+        const CalibrationStyle style = m_selected_style;
+        const bool use_segmented_line_sweep = (style == CalibrationStyle::SegmentedLineSweep);
         if (selected_extrusion_role != "CheckAll") {//don't apply layer ranges to the main object for CheckAll mode(option isn't supported.and it needs to be!!)
-            if(style == 1){//BUG:using this one "works" untill you clear the plate, and it gets stuck in a infinite loop trying to delete nodes, see line 781 of objectDataViewModel.cpp
+            if(style == CalibrationStyle::ClassicLineSweep){//BUG:using this one "works" untill you clear the plate, and it gets stuck in a infinite loop trying to delete nodes, see line 781 of objectDataViewModel.cpp
 
                 if (infill_every_layers > 1 && selected_extrusion_role == "InternalInfill" && infill_dense == false) {
                     ModelConfig range_conf;
@@ -905,7 +907,7 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
                     wxGetApp().obj_list()->layers_editing();
                 }
             }
-            if(style == 2){
+            if(use_segmented_line_sweep){
                 if (infill_every_layers > 1 && selected_extrusion_role == "InternalInfill" && infill_dense == false) {
 
                     wxGetApp().obj_list()->layers_editing(id_item);//could prob use this same thing for the unsupported roles since they need a different layer_height/width
@@ -1317,6 +1319,29 @@ void CalibrationPressureAdvDialog::create_buttons(wxStdDialogButtonSizer* button
         text_generate_count->SetForegroundColour(text_color);
         commonSizer->Add(text_generate_count, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
         commonSizer->Add(nbRuns, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+        wxString style_labels[] = {
+            _L("Classic line sweep (temporarily disabled)"),
+            _L("Segmented line sweep (recommended)")
+        };
+        m_style_choice = new wxChoice(mainPanel, wxID_ANY, wxDefaultPosition, wxDefaultSize, 2, style_labels);
+        m_style_choice->SetSelection(static_cast<int>(CalibrationStyle::SegmentedLineSweep));
+        m_style_choice->SetToolTip(_L("Classic line sweep is temporarily disabled due to a known object-cleanup issue when clearing the plate. Use Segmented line sweep for now."));
+        m_style_choice->Bind(wxEVT_CHOICE, [this](wxCommandEvent& event) {
+            if (event.GetSelection() == static_cast<int>(CalibrationStyle::ClassicLineSweep)) {
+                m_selected_style = CalibrationStyle::SegmentedLineSweep;
+                if (m_style_choice != nullptr)
+                    m_style_choice->SetSelection(static_cast<int>(CalibrationStyle::SegmentedLineSweep));
+                return;
+            }
+
+            m_selected_style = static_cast<CalibrationStyle>(event.GetSelection());
+        });
+
+        wxStaticText* text_style = new wxStaticText(mainPanel, wxID_ANY, _L("Calibration style:"));
+        text_style->SetForegroundColour(text_color);
+        commonSizer->Add(text_style, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+        commonSizer->Add(m_style_choice, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
         
         // Create a button for generating models
         wxButton* generateButton = new wxButton(mainPanel, wxID_FILE1, _L("Generate"));
@@ -1335,6 +1360,7 @@ void CalibrationPressureAdvDialog::create_buttons(wxStdDialogButtonSizer* button
         buttons->Add(mainPanel, 1, wxEXPAND | wxALL, 10);
 
         currentTestCount = wxAtoi(nbRuns->GetValue());
+        m_selected_style = CalibrationStyle::SegmentedLineSweep;
         create_row_controls(dynamicSizer, currentTestCount);
     } else {
 

--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.hpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.hpp
@@ -18,6 +18,11 @@ public:
     void close_me_wrapper(wxCommandEvent& event);
     
 protected:
+    enum class CalibrationStyle : int {
+        ClassicLineSweep = 0,
+        SegmentedLineSweep = 1
+    };
+
     void create_buttons(wxStdDialogButtonSizer* sizer) override;
     void create_row_controls(wxBoxSizer* parent_sizer, int row_count);
     void create_geometry(wxCommandEvent& event_args);
@@ -28,6 +33,8 @@ protected:
 
     //i've set choice boxes for now just to save me typing numbers in when i want to test it :)
     wxComboBox* nbRuns;
+    wxChoice* m_style_choice{ nullptr };
+    CalibrationStyle m_selected_style{ CalibrationStyle::SegmentedLineSweep };
 
     std::vector<wxComboBox*> dynamicFirstPa;      //first layer PA -user manual entry
     std::vector<wxComboBox*> dynamicStartPa;      //starting PA value -user manual entry


### PR DESCRIPTION
### Motivation
- Provide a selectable calibration style for pressure/linear-advance generation instead of a hardcoded constant so users can choose between Orca-like styles.
- Avoid triggering the currently-broken classic generation path by exposing the option but keeping it disabled until object-list cleanup is fixed.

### Description
- Added a `CalibrationStyle` enum and dialog state members `m_style_choice` and `m_selected_style` to `CalibrationPressureAdvDialog` and defaulted to `SegmentedLineSweep`.
- Replaced the hardcoded `int style = 2;` in `create_geometry(...)` with branching on `m_selected_style` and preserved the existing segmented implementation as the default path by using `use_segmented_line_sweep`.
- Added a `wxChoice` control in `create_buttons(...)` labeled `Calibration style:` with two entries (`Classic line sweep (temporarily disabled)` and `Segmented line sweep (recommended)`), wired selection handling, and a tooltip that prevents selecting the Classic style until the cleanup issue is resolved.
- Included `<wx/choice.h>` and updated `resources/calibration/filament_pressure/filament_pressure.html` to document the styles and note that Classic is currently disabled.

### Testing
- Ran static/diff checks and a code search to verify the new symbols and UI strings are present and that the hardcoded style was removed, with no issues reported.
- Verified that the new UI control is initialized to the segmented default and that selection events update `m_selected_style` in the dialog state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20a38bf80832d98c43dfe27483ebd)