### PR TITLE
Follow-up: process existing vendor checkouts when clone fails

### DIFF
--- a/src/platform/download_vendor_bundles.py
+++ b/src/platform/download_vendor_bundles.py
@@ -24,13 +24,17 @@ for url in all_repositories:
 	print(f"Cloning {url}...")
 	repo_name_with_git = os.path.basename(url)
 	repo_name = repo_name_with_git.removesuffix('.git')
+	repo_path = repo_name
 	try:
 		subprocess.run(["git", "clone", url], check=True)
 	except subprocess.CalledProcessError as e:
-		print(f"Failed to clone {url}: {e}")
-		continue
+		if os.path.isdir(repo_path):
+			print(f"Failed to clone {url}, using existing checkout at {repo_path}: {e}")
+		else:
+			print(f"Failed to clone {url}: {e}")
+			continue
 
-	description_path = repo_name + "/description.ini"
+	description_path = repo_path + "/description.ini"
 	if not os.path.exists(description_path):
 		print(f"Failed to process {url}: missing {description_path}")
 		continue
@@ -42,8 +46,8 @@ for url in all_repositories:
 	vendor_id = config.get("vendor", "id")
 	print(f"Vendor ID: {vendor_id}")
 
-	vendor_ini_source = repo_name + "/profiles/" + vendor_id + ".ini"
-	vendor_dir_source = repo_name + "/profiles/" + vendor_id
+	vendor_ini_source = repo_path + "/profiles/" + vendor_id + ".ini"
+	vendor_dir_source = repo_path + "/profiles/" + vendor_id
 	if not os.path.exists(vendor_ini_source) or not os.path.exists(vendor_dir_source):
 		print(f"Failed to process {url}: missing profile files for vendor '{vendor_id}'")
 		continue


### PR DESCRIPTION
### Motivation
- The script unconditionally `continue`-ed on any `git clone` failure which regressed incremental builds because an existing local checkout makes `git clone` exit with an error and the vendor would be skipped. 
- The change aims to treat a clone failure as recoverable when the repository directory already exists locally so vendor resources are still collected on reruns. 
- Preserve the original safe-skip behavior for true clone failures when no local checkout exists.

### Description
- Introduced `repo_path = repo_name` and used `repo_path` consistently for downstream file lookups and copy operations. 
- On `CalledProcessError` from `git clone`, check `os.path.isdir(repo_path)` and, if present, log and continue processing using the existing checkout, otherwise `continue` to skip that vendor. 
- Updated `description_path`, `vendor_ini_source`, and `vendor_dir_source` to use `repo_path` so processing works whether the clone just succeeded or an existing checkout is reused.

### Testing
- Ran `python3 -m py_compile src/platform/download_vendor_bundles.py` which succeeded. 
- Ran `python3 src/platform/download_vendor_bundles.py` which produced the expected `Usage: python download_vendor_bundles.py out_dir_name` message and exited with status `1`. 
- Verified the modified file for the intended control-flow change and absence of syntax errors by inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a213cbb55c832daf6d1db06c855c3f)