### PR TITLE
Reset CheckAll 90° bend Z scaling for base-height roles

### DIFF
--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -639,6 +639,8 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
             const std::string active_role = (selected_extrusion_role == "CheckAll") ? er_role : selected_extrusion_role;
             const double active_layer_height = role_layer_height(active_role);
             er_width_to_scale = magical_scaling(nozzle_diameter, er_width, filament_max_overlap, perimeter_overlap, external_perimeter_overlap, active_layer_height, er_spacing);
+            z_90_bend_pos = (first_layer_height + (base_layer_height * 4)) / 2;
+            z_scale_90_bend = (first_layer_height + (base_layer_height * 4)) / initial_model_height;
             if (active_layer_height != base_layer_height) {
                 z_90_bend_pos = (first_layer_height + (active_layer_height * 5)) / 2;
                 z_scale_90_bend = (first_layer_height + (active_layer_height * 5)) / initial_model_height;


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where base-layer roles processed during `CheckAll` retained stale Z scaling from previously processed non-base-height roles, causing incorrect 90° bend geometry.

### Description
- In `CalibrationPressureAdvDialog::create_geometry` (`src/slic3r/GUI/CalibrationPressureAdvDialog.cpp`) explicitly reset `z_90_bend_pos` and `z_scale_90_bend` to base-layer values before applying any per-role non-base override so `CheckAll` iteration does not leak non-base Z scaling into later base-height roles.

### Testing
- Ran `git diff --check` which succeeded and verified the change was staged and committed (`git status --short` showed the modified file and the commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a214dc5e9c832da8e7d1da721501d6)