### PR TITLE
Fix filament color persistence in Filament Settings

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -2037,8 +2037,14 @@ void ColourPicker::set_internal_any_value(const boost::any &value, bool change_e
         } else {
             str_value = this->m_opt.get_default_value<ConfigOptionStrings>()->get_at(size_t(-1));
         }
+    } else if (this->m_opt.type == coStrings || this->m_opt.type == coString) {
+        str_value = into_u8(any_to_wxstring(value, m_opt, m_opt_key_idx.idx));
     } else if (this->m_opt.type == coGraph || this->m_opt.type == coGraphs) {
         str_value = boost::any_cast<std::string>(value);
+    } else if (this->m_opt.type == coInt) {
+        str_value = wxColour((unsigned long) boost::any_cast<int32_t>(value)).GetAsString(wxC2S_HTML_SYNTAX).ToStdString();
+    } else if (this->m_opt.type == coInts) {
+        str_value = wxColour((unsigned long) boost::any_cast<int32_t>(value)).GetAsString(wxC2S_HTML_SYNTAX).ToStdString();
     }
     // can be ConfigOptionDef::GUIType::color
     const wxString clr_str(str_value);
@@ -2500,4 +2506,3 @@ boost::any &SliderCtrl::get_value()
 
 
 } // Slic3r :: GUI
-


### PR DESCRIPTION
### Motivation
- Filament color values were not reliably reloaded into the GUI color picker, causing the filament color to appear unset after loading presets or configs because `ColourPicker::set_internal_any_value` did not handle scalar string or integer-backed color option types.

### Description
- Updated `ColourPicker::set_internal_any_value` in `src/slic3r/GUI/Field.cpp` to extract scalar color strings using `any_to_wxstring` and `into_u8` for `coString`/`coStrings` options.
- Added conversion for integer-backed color options (`coInt`/`coInts`) by converting numeric values to an HTML color string via `wxColour(...).GetAsString(wxC2S_HTML_SYNTAX)` so the picker displays numeric color representations correctly.
- Preserved existing handling for graph-based color values (`coGraph`/`coGraphs`) and the legacy vector-`coStrings` branch.

### Testing
- Ran repository static checks (`git diff --check`) and code inspections; no check failures were reported and the modified code path was reviewed.
- Verified via source-level searches and file review that the `ColourPicker` value-loading logic now covers `coString`/`coStrings` and `coInt`/`coInts` cases in `src/slic3r/GUI/Field.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a215f634b8832da21ea19c67edea0f)