### PR TITLE
Fix overhang/perimeter G-code role mapping to handle modifier-composed roles

### DIFF
--- a/src/libslic3r/ExtrusionRole.cpp
+++ b/src/libslic3r/ExtrusionRole.cpp
@@ -18,16 +18,20 @@ GCodeExtrusionRole extrusion_role_to_gcode_extrusion_role(ExtrusionRole role)
 {
     assert(role != ExtrusionRole::Mixed);
     if (role == ExtrusionRole::None)                return GCodeExtrusionRole::None;
-    if (role == ExtrusionRole::ExternalPerimeter)   return GCodeExtrusionRole::ExternalPerimeter;
-    if (role == ExtrusionRole::Perimeter)           return GCodeExtrusionRole::Perimeter;
-    if (role == ExtrusionRole::OverhangExternalPerimeter) return GCodeExtrusionRole::OverhangPerimeter;
-    if (role == ExtrusionRole::OverhangPerimeter)   return GCodeExtrusionRole::OverhangPerimeter;
-    if (role == ExtrusionRole::InternalInfill)      return GCodeExtrusionRole::InternalInfill;
-    if (role == ExtrusionRole::SolidInfill)         return GCodeExtrusionRole::SolidInfill;
-    if (role == ExtrusionRole::TopSolidInfill)      return GCodeExtrusionRole::TopSolidInfill;
-    if (role == ExtrusionRole::Ironing)             return GCodeExtrusionRole::Ironing;
-    if (role == ExtrusionRole::BridgeInfill)        return GCodeExtrusionRole::BridgeInfill;
-    if (role == ExtrusionRole::InternalBridgeInfill)return GCodeExtrusionRole::InternalBridgeInfill;
+    if (role.is_perimeter()) {
+        if (role.is_overhang())
+            return GCodeExtrusionRole::OverhangPerimeter;
+        return role.is_external_perimeter() ? GCodeExtrusionRole::ExternalPerimeter : GCodeExtrusionRole::Perimeter;
+    }
+    if (role.is_infill()) {
+        if (role.is_bridge())
+            return role.is_external() ? GCodeExtrusionRole::BridgeInfill : GCodeExtrusionRole::InternalBridgeInfill;
+        if (role == ExtrusionRole::Ironing)
+            return GCodeExtrusionRole::Ironing;
+        if (role.is_solid_infill())
+            return role.is_external() ? GCodeExtrusionRole::TopSolidInfill : GCodeExtrusionRole::SolidInfill;
+        return GCodeExtrusionRole::InternalInfill;
+    }
     if (role == ExtrusionRole::ThinWall)            return GCodeExtrusionRole::ThinWall;
     if (role == ExtrusionRole::GapFill)             return GCodeExtrusionRole::GapFill;
     if (role == ExtrusionRole::Skirt)               return GCodeExtrusionRole::Skirt;


### PR DESCRIPTION
### Motivation
- Perimeter roles that include bridge/overhang modifiers were sometimes not serialized as overhang perimeters because mapping used exact enum equality checks.
- The intent is to make role-to-GCode serialization tolerant to derived or combined `ExtrusionRole` modifiers so overhang perimeters are correctly identified in preview and G-code output.

### Description
- Refactored `extrusion_role_to_gcode_extrusion_role()` to classify roles by properties using predicates like `is_perimeter()`, `is_overhang()`, `is_infill()`, and `is_bridge()` instead of strict equality checks.
- Ensures any perimeter carrying the bridge modifier is emitted as `GCodeExtrusionRole::OverhangPerimeter` and preserves correct mapping for external/internal/bridge/solid/top-solid infill cases.
- Change implemented in `src/libslic3r/ExtrusionRole.cpp` (replacement of several equality branches with property-based logic).

### Testing
- Ran configuration with `cmake --preset default` to validate build configuration, but configure failed due to missing DBus development libraries (`Could NOT find DBus (missing: DBUS_INCLUDE_DIRS DBUS_LIBRARIES)`), so a full build/test could not be performed in this environment.
- No unit tests were executed in this environment after the change due to the configuration failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21759c1d8832da845b67f0d243f93)