### PR TITLE
Preserve ThinWall mapping before perimeter classification

### DIFF
--- a/src/libslic3r/ExtrusionRole.cpp
+++ b/src/libslic3r/ExtrusionRole.cpp
@@ -18,6 +18,7 @@ GCodeExtrusionRole extrusion_role_to_gcode_extrusion_role(ExtrusionRole role)
 {
     assert(role != ExtrusionRole::Mixed);
     if (role == ExtrusionRole::None)                return GCodeExtrusionRole::None;
+    if (role == ExtrusionRole::ThinWall)            return GCodeExtrusionRole::ThinWall;
     if (role.is_perimeter()) {
         if (role.is_overhang())
             return GCodeExtrusionRole::OverhangPerimeter;
@@ -32,7 +33,6 @@ GCodeExtrusionRole extrusion_role_to_gcode_extrusion_role(ExtrusionRole role)
             return role.is_external() ? GCodeExtrusionRole::TopSolidInfill : GCodeExtrusionRole::SolidInfill;
         return GCodeExtrusionRole::InternalInfill;
     }
-    if (role == ExtrusionRole::ThinWall)            return GCodeExtrusionRole::ThinWall;
     if (role == ExtrusionRole::GapFill)             return GCodeExtrusionRole::GapFill;
     if (role == ExtrusionRole::Skirt)               return GCodeExtrusionRole::Skirt;
     if (role == ExtrusionRole::SupportMaterial)     return GCodeExtrusionRole::SupportMaterial;


### PR DESCRIPTION
### Motivation
- Thin-wall extrusions carry perimeter/external bits and were being misclassified as perimeters by the generic `is_perimeter()` branch, regressing serialization for thin walls.
- The change restores the intended serialization so thin-wall roles remain `GCodeExtrusionRole::ThinWall` for viewer coloring and role-specific handling.

### Description
- Moved the `if (role == ExtrusionRole::ThinWall)` check to appear before the `if (role.is_perimeter())` branch in `extrusion_role_to_gcode_extrusion_role()`.
- This prevents thin-wall roles from being captured by the generic perimeter classification and ensures they serialize to `GCodeExtrusionRole::ThinWall`.
- Change location: `src/libslic3r/ExtrusionRole.cpp` (adjusted role-mapping precedence).

### Testing
- Ran configuration with `cmake --preset default` to validate the tree still configures; configuration started but failed due to missing DBus development libraries (`DBUS_INCLUDE_DIRS`/`DBUS_LIBRARIES`).
- No further automated build or unit tests were executed in this environment because the configure step could not complete due to the missing DBus dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21c9e783c832d9400460af9780b31)