### PR TITLE
Keep split overhang segments tagged as overhang perimeters

### DIFF
--- a/src/libslic3r/GCode/ExtrusionProcessor.cpp
+++ b/src/libslic3r/GCode/ExtrusionProcessor.cpp
@@ -139,8 +139,14 @@ ExtrusionPaths calculate_and_split_overhanging_extrusions(const ExtrusionPath   
     }
     // Keep the overhang role on split segments so TYPE tags and preview coloring
     // remain consistent even on short perimeter fragments.
-    for (ExtrusionPath &res_path : result)
+    for (ExtrusionPath &res_path : result) {
         assert(res_path.attributes().overhang_attributes);
+        if (res_path.attributes().overhang_attributes.has_value() &&
+            res_path.role().is_perimeter() &&
+            !res_path.role().is_overhang()) {
+            res_path.set_role(res_path.role() | ExtrusionRoleModifier::ERM_Bridge);
+        }
+    }
 #ifdef _DEBUG
     for (auto &path : result) {
         assert(path.attributes().overhang_attributes.has_value());


### PR DESCRIPTION
### Motivation
- Small perimeter fragments produced when splitting overhanging extrusions were losing their overhang role and appearing as plain external perimeters in preview/TYPE classification, which is misleading and hides intended overhang handling.

### Description
- In `src/libslic3r/GCode/ExtrusionProcessor.cpp` ensure split segments keep the overhang tagging by checking `overhang_attributes` and forcing the perimeter role to include `ExtrusionRoleModifier::ERM_Bridge` when the path is a perimeter but not already flagged as overhang.
- The change is applied inside the existing post-split loop that previously only asserted the presence of `overhang_attributes`, preserving the prior assertions and preview coloring behavior.

### Testing
- Ran `git diff --check` which reported no issues and passed.
- Attempted `cmake -S . -B build -GNinja` to validate configuration but it failed in this environment due to missing DBus development packages (failure unrelated to the code change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21f15f8e8832da665047ac0232ea3)