### PR TITLE
Share semantic UI color derivation across platforms

### DIFF
--- a/src/slic3r/GUI/BitmapComboBox.cpp
+++ b/src/slic3r/GUI/BitmapComboBox.cpp
@@ -161,9 +161,9 @@ void BitmapComboBox::DrawBackground_(wxDC& dc, const wxRect& rect, int WXUNUSED(
     {
         const int vSizeDec = 0;  // Vertical size reduction of selection rectangle edges
 
-        dc.SetTextForeground(wxGetApp().get_label_highlight_clr());
+        dc.SetTextForeground(wxGetApp().get_style_role_color("combo.text.selected"));
 
-        wxColour selCol = wxGetApp().get_highlight_default_clr();
+        wxColour selCol = wxGetApp().get_style_role_color("combo.bg.selected");
         dc.SetPen(selCol);
         dc.SetBrush(selCol);
         dc.DrawRectangle(rect.x,
@@ -173,15 +173,11 @@ void BitmapComboBox::DrawBackground_(wxDC& dc, const wxRect& rect, int WXUNUSED(
     }
     else
     {
-        dc.SetTextForeground(flags & ODCB_PAINTING_DISABLED ? wxColour(108,108,108) : wxGetApp().get_label_clr_default());
+        dc.SetTextForeground(flags & ODCB_PAINTING_DISABLED ? wxColour(108,108,108) : wxGetApp().get_style_role_color("combo.text.default"));
 
-        wxColour selCol = flags & ODCB_PAINTING_DISABLED ? 
-#ifdef _MSW_DARK_MODE
-            wxRGBToColour(NppDarkMode::GetSofterBackgroundColor()) :
-#else
-            wxGetApp().get_highlight_default_clr() :
-#endif
-            wxGetApp().get_window_default_clr();
+        wxColour selCol = flags & ODCB_PAINTING_DISABLED ?
+            wxGetApp().get_style_role_color("combo.bg.disabled") :
+            wxGetApp().get_style_role_color("combo.bg.default");
         dc.SetPen(selCol);
         dc.SetBrush(selCol);
         dc.DrawRectangle(rect);
@@ -205,4 +201,3 @@ void BitmapComboBox::Rescale()
 #endif
 
 }}
-

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1996,20 +1996,36 @@ void GUI_App::init_ui_colours()
 #endif
 
     const bool is_dark_mode = dark_mode();
-#ifdef _MSW_DARK_MODE
-    m_color_highlight_label_default = is_dark_mode ? wxColour(230, 230, 230): wxSystemSettings::GetColour(/*wxSYS_COLOUR_HIGHLIGHTTEXT*/wxSYS_COLOUR_WINDOWTEXT);
-    m_color_highlight_default       = is_dark_mode ? wxColour(78, 78, 78)   : wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
-    // Prusa: is_dark_mode ? wxColour(253, 111, 40) : wxColour(252, 77, 1); (fd6f28 & fc4d01) SV: 84 99 ; 100 99 (with light hue diff)
-    // custom background color for the notbook (tab) button
-    m_color_hovered_btn             = is_dark_mode ? wxColour(253, 111, 40) : wxColour(252, 77, 1);
-    // text color on hover on any button
-    m_color_hovered_btn_label       = is_dark_mode ? wxColour(253, 111, 40) : wxColour(252, 77, 1);
-    // m_color_default_btn_label: color of the ok button text in normal state (default button when clickingon enter). And graph line
-    m_color_default_btn_label       = is_dark_mode ? wxColour(255, 181, 100): wxColour(203, 61, 0);
-    // Prusa: is_dark_mode ? wxColour(95, 73, 62)   : wxColour(228, 220, 216); (f2ba9e & e4dcd8) SV: 35 37 ;  5 90
-    m_color_selected_btn_bg         = is_dark_mode ? wxColour(95, 73, 62)   : wxColour(228, 220, 216);
-#endif
+    m_color_highlight_label_default = is_dark_mode ? wxColour(230, 230, 230) : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    m_color_highlight_default       = is_dark_mode ? wxColour(78, 78, 78) : wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+    derive_semantic_ui_colours();
     m_color_window_default          = is_dark_mode ? wxColour(43, 43, 43)   : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+}
+
+void GUI_App::derive_semantic_ui_colours()
+{
+    const bool is_dark_mode = dark_mode();
+    const auto resolve = [this, is_dark_mode](float dark_sat, float dark_val, float light_sat, float light_val, AppConfig::EAppColorType type, const wxColour& fallback) {
+        if (app_config == nullptr)
+            return fallback;
+
+        const float saturation = is_dark_mode ? dark_sat : light_sat;
+        const float value      = is_dark_mode ? dark_val : light_val;
+        return color_from_int(app_config->create_color(saturation, value, type));
+    };
+
+    // custom background color for notebook/tab buttons in hover and active states.
+    m_color_hovered_btn = resolve(0.84f, 0.99f, 1.00f, 0.99f, AppConfig::EAppColorType::Main,
+                                  is_dark_mode ? wxColour(253, 111, 40) : wxColour(252, 77, 1));
+    // text color on hover on button-like controls.
+    m_color_hovered_btn_label = resolve(0.84f, 0.99f, 1.00f, 0.99f, AppConfig::EAppColorType::Highlight,
+                                        is_dark_mode ? wxColour(253, 111, 40) : wxColour(252, 77, 1));
+    // default button text (enter key action), graph line accent.
+    m_color_default_btn_label = resolve(0.90f, 0.80f, 1.00f, 0.80f, AppConfig::EAppColorType::Highlight,
+                                        is_dark_mode ? wxColour(255, 181, 100) : wxColour(203, 61, 0));
+    // selected tab/button background accent.
+    m_color_selected_btn_bg   = resolve(0.35f, 0.37f, 0.05f, 0.90f, AppConfig::EAppColorType::Main,
+                                        is_dark_mode ? wxColour(95, 73, 62) : wxColour(228, 220, 216));
 }
 
 void GUI_App::update_ui_colours_from_appconfig()
@@ -2076,17 +2092,7 @@ void GUI_App::update_ui_colours_from_appconfig()
     Slic3r::GUI::Widget::set_clr_background_focused(change_endian_int24(
         app_config->create_color(0.86f, 0.93f, AppConfig::EAppColorType::Main)));
 
-#ifdef _WIN32
-    const bool is_dark_mode = dark_mode();
-    m_color_hovered_btn = is_dark_mode ? color_from_int(app_config->create_color(0.84f, 0.99f, AppConfig::EAppColorType::Main)) :
-        color_from_int(app_config->create_color(1.00f, 0.99f, AppConfig::EAppColorType::Main));
-    m_color_hovered_btn_label = is_dark_mode ? color_from_int(app_config->create_color(0.84f, 0.99f, AppConfig::EAppColorType::Highlight)) :
-        color_from_int(app_config->create_color(1.00f, 0.99f, AppConfig::EAppColorType::Highlight));
-    m_color_default_btn_label = is_dark_mode ? color_from_int(app_config->create_color(0.9f, 0.80f, AppConfig::EAppColorType::Highlight)) :
-        color_from_int(app_config->create_color(1.00f, 0.80f, AppConfig::EAppColorType::Highlight));
-    m_color_selected_btn_bg = is_dark_mode ? color_from_int(app_config->create_color(0.35f, 0.37f, AppConfig::EAppColorType::Main)) :
-        color_from_int(app_config->create_color(0.05f, 0.9f, AppConfig::EAppColorType::Main));
-#endif
+    derive_semantic_ui_colours();
 
     //also update imgui color cache... can be moved if you have a better placee it 
     m_imgui->reset_color();
@@ -2118,6 +2124,23 @@ const wxColour& GUI_App::get_style_role_color(const std::string& role) const
         return m_color_default_btn_label;
     if (role == "tab.text.selected")
         return m_color_hovered_btn_label;
+    if (role == "combo.bg.selected")
+        return m_color_highlight_default;
+    if (role == "combo.bg.disabled") {
+#ifdef _MSW_DARK_MODE
+        if (dark_mode()) {
+            static const wxColour disabled_dark = wxRGBToColour(NppDarkMode::GetSofterBackgroundColor());
+            return disabled_dark;
+        }
+#endif
+        return m_color_highlight_default;
+    }
+    if (role == "combo.bg.default")
+        return m_color_window_default;
+    if (role == "combo.text.selected")
+        return m_color_highlight_label_default;
+    if (role == "combo.text.default")
+        return dark_mode() ? m_color_dark_mode_label_default : m_color_label_default;
 
     return dark_mode() ? m_color_dark_mode_label_default : m_color_label_default;
 }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -214,6 +214,7 @@ public:
     const std::vector<std::string> get_mode_default_palette();
     void            init_ui_colours();
     void            update_ui_colours_from_appconfig();
+    void            derive_semantic_ui_colours();
     void            update_label_colours();
     // update color mode for window
     void            UpdateDarkUI(wxWindow *window, bool highlited = false, bool just_font = false);
@@ -246,6 +247,21 @@ public:
     void                    set_mode_palette(const std::vector<wxColour> &palette);
 #endif
 
+    // Semantic color role map:
+    // - tab.bg.default     : Neutral tab/chrome surface (idle state).
+    // - tab.bg.hover       : Tab/chrome surface while hovered.
+    // - tab.bg.selected    : Tab/chrome surface while selected.
+    // - tab.border.default : Neutral tab/chrome border.
+    // - tab.border.active  : Active/hovered/selected tab border accent.
+    // - tab.border.focus   : Keyboard focus ring for tab-like controls.
+    // - tab.text.default   : Default text for tabs and similar controls.
+    // - tab.text.hover     : Hovered text accent for tabs and similar controls.
+    // - tab.text.selected  : Selected text accent for tabs and similar controls.
+    // - combo.bg.selected  : Selected list-row background in bitmap combo box.
+    // - combo.bg.disabled  : Disabled list-row background in bitmap combo box.
+    // - combo.bg.default   : Default list-row background in bitmap combo box.
+    // - combo.text.selected: Selected list-row text in bitmap combo box.
+    // - combo.text.default : Default list-row text in bitmap combo box.
     const wxColour& get_label_highlight_clr()   { return m_color_highlight_label_default; }
     const wxColour& get_highlight_default_clr() { return m_color_highlight_default; }
     const wxColour& get_color_hovered_btn_label() { return m_color_hovered_btn_label; }

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -20,6 +20,16 @@
 
 namespace
 {
+constexpr const char* ROLE_TAB_BG_DEFAULT = "tab.bg.default";
+constexpr const char* ROLE_TAB_BG_HOVER = "tab.bg.hover";
+constexpr const char* ROLE_TAB_BG_SELECTED = "tab.bg.selected";
+constexpr const char* ROLE_TAB_BORDER_DEFAULT = "tab.border.default";
+constexpr const char* ROLE_TAB_BORDER_ACTIVE = "tab.border.active";
+constexpr const char* ROLE_TAB_BORDER_FOCUS = "tab.border.focus";
+constexpr const char* ROLE_TAB_TEXT_DEFAULT = "tab.text.default";
+constexpr const char* ROLE_TAB_TEXT_HOVER = "tab.text.hover";
+constexpr const char* ROLE_TAB_TEXT_SELECTED = "tab.text.selected";
+
 void draw_tab_chrome(wxDC& dc, const wxRect& button_rect, const wxRect& client_rect, const wxColour& background, const wxColour& border, const wxColour* focus_ring, int radius, int bottom_line_height)
 {
     wxRect chrome = button_rect;
@@ -99,12 +109,12 @@ void ButtonsListCtrl::OnPaint(wxPaintEvent&)
 
             const bool is_focused = state == TabVisualState::Focused;
             const wxColour& background = app.get_style_role_color(
-                state == TabVisualState::Selected ? "tab.bg.selected" :
-                state == TabVisualState::Hovered  ? "tab.bg.hover"    :
-                                                    "tab.bg.default");
+                state == TabVisualState::Selected ? ROLE_TAB_BG_SELECTED :
+                state == TabVisualState::Hovered  ? ROLE_TAB_BG_HOVER    :
+                                                    ROLE_TAB_BG_DEFAULT);
             const wxColour& border = app.get_style_role_color(
-                (state == TabVisualState::Selected || state == TabVisualState::Focused) ? "tab.border.active" : "tab.border.default");
-            const wxColour* focus_ring = is_focused ? &app.get_style_role_color("tab.border.focus") : nullptr;
+                (state == TabVisualState::Selected || state == TabVisualState::Focused) ? ROLE_TAB_BORDER_ACTIVE : ROLE_TAB_BORDER_DEFAULT);
+            const wxColour* focus_ring = is_focused ? &app.get_style_role_color(ROLE_TAB_BORDER_FOCUS) : nullptr;
             draw_tab_chrome(dc, button->GetRect(), client_rect, background, border, focus_ring, radius, m_line_margin);
         }
     }
@@ -115,8 +125,8 @@ void ButtonsListCtrl::OnPaint(wxPaintEvent&)
             if (!mode_btn)
                 continue;
             const bool selected = mode_btn->is_selected();
-            const wxColour& bg = app.get_style_role_color(selected ? "tab.bg.selected" : "tab.bg.default");
-            const wxColour& border = app.get_style_role_color(selected ? "tab.border.active" : "tab.border.default");
+            const wxColour& bg = app.get_style_role_color(selected ? ROLE_TAB_BG_SELECTED : ROLE_TAB_BG_DEFAULT);
+            const wxColour& border = app.get_style_role_color(selected ? ROLE_TAB_BORDER_ACTIVE : ROLE_TAB_BORDER_DEFAULT);
             draw_tab_chrome(dc, mode_btn->GetRect(), client_rect, bg, border, nullptr, radius, m_line_margin);
             apply_tab_state(mode_btn, selected ? TabVisualState::Selected : TabVisualState::Default);
 #ifdef __APPLE__
@@ -125,7 +135,7 @@ void ButtonsListCtrl::OnPaint(wxPaintEvent&)
         }
     }
 
-    dc.SetPen(wxPen(app.get_style_role_color("tab.border.active"), m_line_margin));
+    dc.SetPen(wxPen(app.get_style_role_color(ROLE_TAB_BORDER_ACTIVE), m_line_margin));
     dc.DrawLine(client_rect.GetLeft(), client_rect.GetBottom() - m_line_margin / 2,
                 client_rect.GetRight(), client_rect.GetBottom() - m_line_margin / 2);
 }
@@ -145,9 +155,9 @@ void ButtonsListCtrl::apply_tab_state(ScalableButton* button, TabVisualState sta
 {
     auto &app = Slic3r::GUI::wxGetApp();
     const wxColour& text_color = app.get_style_role_color(
-        state == TabVisualState::Selected ? "tab.text.selected" :
-        state == TabVisualState::Hovered  ? "tab.text.hover"    :
-                                            "tab.text.default");
+        state == TabVisualState::Selected ? ROLE_TAB_TEXT_SELECTED :
+        state == TabVisualState::Hovered  ? ROLE_TAB_TEXT_HOVER    :
+                                            ROLE_TAB_TEXT_DEFAULT);
 
     button->SetForegroundColour(text_color);
 #ifdef __APPLE__

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5961,7 +5961,7 @@ void TabPrinter::update_machine_limits_description(const MachineLimitsUsage usag
     //no need to worry for "silent" version, as it's only for marlin.
     if (usage == MachineLimitsUsage::EmitToGCode) {
         wxColour grey_color(128, 128, 128);
-        wxColour black_color = wxGetApp().get_label_clr_default();//wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+        wxColour black_color = wxGetApp().get_style_role_color("tab.text.default");
         Field* field;
         std::vector<std::string> axes{ "x", "y", "z", "e" };
 
@@ -6008,7 +6008,7 @@ void TabPrinter::update_machine_limits_description(const MachineLimitsUsage usag
     } else {
         Field* field;
         std::vector<std::string> axes{ "x", "y", "z", "e" };
-        const wxColour color = wxGetApp().get_label_clr_default();//wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+        const wxColour color = wxGetApp().get_style_role_color("tab.text.default");
         for (const std::string& axis : axes) {
             field = m_active_page->get_field("machine_max_feedrate_" + axis, 0);
             if (field) dynamic_cast<TextInput*>(field->getWindow())->SetForegroundColour(color);


### PR DESCRIPTION
### Motivation
- Remove platform-only color derivation guarded by `_WIN32` so interactive UI colors are derived consistently on all platforms from `AppConfig::create_color(...)` and dark/light mode. 
- Replace ad-hoc color usage with semantic role tokens to make future UI work reuse named roles instead of special-case colors.

### Description
- Add a shared helper `GUI_App::derive_semantic_ui_colours()` that computes `m_color_hovered_btn`, `m_color_hovered_btn_label`, `m_color_default_btn_label` and `m_color_selected_btn_bg` from `AppConfig::create_color(...)` and dark/light mode, and call it from both `init_ui_colours()` and `update_ui_colours_from_appconfig()` for all platforms (keeps platform-specific exceptions only where necessary). 
- Extend `GUI_App::get_style_role_color()` with additional `combo.*` roles and wire existing tab roles to the new semantic tokens. 
- Add a documented semantic role map comment block in `GUI_App.hpp` and declare `derive_semantic_ui_colours()` there to guide future usage. 
- Update callers to use semantic roles: replace ad-hoc color usage in `src/slic3r/GUI/Notebook.cpp`, `src/slic3r/GUI/Tab.cpp`, and `src/slic3r/GUI/BitmapComboBox.cpp` to call `get_style_role_color("...")` (or role constants) instead of special-case color getters.

### Testing
- Ran `git diff --check` to verify no whitespace or trivial diff issues, which completed successfully. 
- Ran `git status --short` to verify working tree changes are as expected, which reported the modified files. 
- No automated unit/integration GUI tests were available in this change, so runtime behavior should be validated on target platforms during manual UI testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2232bc50c832dbb871f94684b5391)