### PR TITLE
Unify notebook implementation, remove wxNB_NOPAGETHEME, add compact tab density option

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -175,6 +175,9 @@ void AppConfig::set_defaults()
         if (get("tab_icon_size").empty())
             set("tab_icon_size", "32");
 
+        if (get("tab_density_compact").empty())
+            set("tab_density_compact", "0");
+
         if (get("font_size").empty())
             set("font_size", "0");
 

--- a/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
+++ b/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
@@ -884,13 +884,13 @@ CreateMMUTiledCanvas::CreateMMUTiledCanvas(GUI_App* app, MainFrame* mainframe)
 #ifdef _MSW_DARK_MODE
     wxBookCtrlBase* tabs;
     //	if (wxGetApp().dark_mode())
-    tabs = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME | wxNB_DEFAULT);
+    tabs = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_DEFAULT);
     /*	else {
-            tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME | wxNB_DEFAULT);
+            tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_DEFAULT);
             tabs->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
         }*/
 #else
-    wxNotebook* tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME | wxNB_DEFAULT);
+    wxNotebook* tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_DEFAULT);
     tabs->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
 #endif
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1066,18 +1066,13 @@ void MainFrame::init_tabpanel()
 {
     wxGetApp().update_ui_colours_from_appconfig();
 
-    // wxNB_NOPAGETHEME: Disable Windows Vista theme for the Notebook background. The theme performance is terrible on Windows 10
-    // with multiple high resolution displays connected.
-#ifdef _USE_CUSTOM_NOTEBOOK
+    const long tab_style = wxNB_TOP | wxTAB_TRAVERSAL;
     if (wxGetApp().tabs_as_menu()) {
-        m_tabpanel = new wxSimplebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME);
+        m_tabpanel = new wxSimplebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, tab_style);
 //        wxGetApp().UpdateDarkUI(m_tabpanel);
     }
     else
-        m_tabpanel = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME, true);
-#else
-    m_tabpanel = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME);
-#endif
+        m_tabpanel = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, tab_style, true);
 
     wxGetApp().UpdateDarkUI(m_tabpanel);
 
@@ -1085,32 +1080,7 @@ void MainFrame::init_tabpanel()
     m_tabpanel->Hide();
     m_settings_dialog.set_tabpanel(m_tabpanel);
 
-#ifndef _USE_CUSTOM_NOTEBOOK
-    int icon_size = 0;
-    try {
-        icon_size = atoi(wxGetApp().app_config->get("tab_icon_size").c_str());
-    }
-    catch (std::exception e) {}
-    // icons for m_tabpanel tabs
-    wxImageList* img_list = nullptr;
-    if (icon_size >= 8) {
-        std::vector<std::string> icon_list =  { "editor_menu", "layers", "preview_menu", "cog", "spool_cog",  "printer_cog",  "resin_cog",    "sla_printer_cog" };
-        if (icon_size < 16)
-            icon_list =                       { "editor_menu", "layers", "preview_menu", "cog", "spool",      "printer",      "resin",        "sla_printer" };
-        for (std::string icon_name : icon_list) {
-            const wxBitmap bmp = get_bmp_bundle(icon_name, icon_size)->GetBitmap(wxDefaultSize);
-            if (img_list == nullptr)
-                img_list = new wxImageList(bmp.GetWidth(), bmp.GetHeight());
-            img_list->Add(bmp);
-        }
-    }
-    m_tabpanel->AssignImageList(img_list);
-#endif
-#ifdef __WXMSW__
     m_tabpanel->Bind(wxEVT_BOOKCTRL_PAGE_CHANGED, [this](wxBookCtrlEvent& e) {
-#else
-    m_tabpanel->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, [this](wxBookCtrlEvent& e) {
-#endif
         if (m_tabpanel_stop_event)
             return;
         // merill: ????? it should already be called by on_change... like other events

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -30,6 +30,12 @@ constexpr const char* ROLE_TAB_TEXT_DEFAULT = "tab.text.default";
 constexpr const char* ROLE_TAB_TEXT_HOVER = "tab.text.hover";
 constexpr const char* ROLE_TAB_TEXT_SELECTED = "tab.text.selected";
 
+bool use_compact_tab_density()
+{
+    auto *app_config = Slic3r::GUI::wxGetApp().app_config;
+    return app_config != nullptr && app_config->get_bool("tab_density_compact");
+}
+
 void draw_tab_chrome(wxDC& dc, const wxRect& button_rect, const wxRect& client_rect, const wxColour& background, const wxColour& border, const wxColour* focus_ring, int radius, int bottom_line_height)
 {
     wxRect chrome = button_rect;
@@ -60,12 +66,13 @@ ButtonsListCtrl::ButtonsListCtrl(wxWindow *parent, bool add_mode_buttons/* = fal
 #endif //__WINDOWS__
 
     int em = em_unit(this);// Slic3r::GUI::wxGetApp().em_unit();
+    const double compact_factor = use_compact_tab_density() ? 0.75 : 1.0;
 #ifdef __WINDOWS__
-    m_btn_margin = std::lround(0.3 * em);
+    m_btn_margin = std::lround(0.3 * em * compact_factor);
 #else
-    m_btn_margin = std::lround(0.4 * em);
+    m_btn_margin = std::lround(0.4 * em * compact_factor);
 #endif
-    m_line_margin = std::lround(0.1 * em);
+    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 
@@ -174,14 +181,15 @@ void ButtonsListCtrl::UpdateMode()
 void ButtonsListCtrl::Rescale()
 {
     int em = em_unit(this);
+    const double compact_factor = use_compact_tab_density() ? 0.75 : 1.0;
 
 #ifdef __APPLE__
     // Adjust margins and sizes specifically for macOS
-    m_btn_margin = std::lround(0.4 * em);
-    m_line_margin = std::lround(0.1 * em);
+    m_btn_margin = std::lround(0.4 * em * compact_factor);
+    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
 #else
-    m_btn_margin = std::lround(0.3 * em);
-    m_line_margin = std::lround(0.1 * em);
+    m_btn_margin = std::lround(0.3 * em * compact_factor);
+    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
 #endif //__APPLE__
 
     m_buttons_sizer->SetVGap(m_btn_margin);  // Adjust vertical gap here
@@ -229,6 +237,9 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString& text, bool bSelect/* 
         wxBU_EXACTFIT | wxNO_BORDER | (bmp_name.empty() ? 0 : wxBU_LEFT),
 #endif //__APPLE__
         false, bmp_size);
+
+    if (use_compact_tab_density())
+        btn->SetMinSize(wxSize(-1, std::lround(1.8 * em_unit(this))));
 
     apply_tab_state(btn, bSelect ? TabVisualState::Selected : TabVisualState::Default);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -485,9 +485,9 @@ void PreferencesDialog::build()
 	auto app_config = get_app_config();
 
 #ifdef _MSW_DARK_MODE
-		tabs = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_NOPAGETHEME | wxNB_DEFAULT);
+		tabs = new Notebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL | wxNB_DEFAULT);
 #else
-    tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL  |wxNB_NOPAGETHEME | wxNB_DEFAULT );
+    tabs = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxTAB_TRAVERSAL   | wxNB_DEFAULT );
 #ifdef __linux__
 	tabs->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, [this](wxBookCtrlEvent& e) {
 		e.Skip();
@@ -974,6 +974,12 @@ void PreferencesDialog::build()
 			6,
 			app_config->get_int("tab_icon_size"));
 		m_values_need_restart.push_back("tab_icon_size");
+
+		append_bool_option(m_tabid_2_optgroups.back().back(), "tab_density_compact",
+			L("Use compact tab density"),
+			L("Reduce tab button paddings to better fit laptop-sized displays. Disable for roomier tab spacing on larger screens."),
+			app_config->get_bool("tab_density_compact"));
+		m_values_need_restart.push_back("tab_density_compact");
 		
 		append_int_option(m_tabid_2_optgroups.back().back(), "font_size",
 			L("Font size"),

--- a/src/slic3r/GUI/wxExtensions.hpp
+++ b/src/slic3r/GUI/wxExtensions.hpp
@@ -31,10 +31,7 @@ void                sys_color_changed_menu(wxMenu* menu);
 inline void         sys_color_changed_menu(wxMenu* /* menu */) {}
 #endif // no __linux__
 
-#ifdef _MSW_DARK_MODE
-#define _USE_CUSTOM_NOTEBOOK 1
-#endif
-#ifdef __APPLE__
+#ifndef _USE_CUSTOM_NOTEBOOK
 #define _USE_CUSTOM_NOTEBOOK 1
 #endif
 


### PR DESCRIPTION
### Motivation
- Converge the multiple notebook/tab code paths into a single, consistent framework so styling, selection events and visual updates are centralized.
- Prefer native theming unless profiling shows `wxNB_NOPAGETHEME` is needed, avoiding platform-specific theme-workarounds scattered throughout the code.
- Provide a user-facing switch to control tab density to better support laptop vs large-screen layouts.

### Description
- Make the custom `Notebook` the primary notebook path by ensuring the `_USE_CUSTOM_NOTEBOOK` macro is defined in `wxExtensions.hpp` and simplifying `MainFrame::init_tabpanel()` to one creation flow that uses a common `tab_style` (removed `wxNB_NOPAGETHEME` from the default paths). (files: `src/slic3r/GUI/wxExtensions.hpp`, `src/slic3r/GUI/MainFrame.cpp`)
- Centralize page-change handling by binding a single `wxEVT_BOOKCTRL_PAGE_CHANGED` handler in `MainFrame::init_tabpanel()` so selected-page events and activation logic live in one place. (file: `src/slic3r/GUI/MainFrame.cpp`)
- Remove `wxNB_NOPAGETHEME` from other notebook users so native theming can apply by default (adjusted `Preferences` and `CreateMMUTiledCanvas`). (files: `src/slic3r/GUI/Preferences.cpp`, `src/slic3r/GUI/CreateMMUTiledCanvas.cpp`)
- Add a new config option `tab_density_compact` (default `0`) and expose it in the Preferences UI so users can toggle compact tab density. (files: `src/libslic3r/AppConfig.cpp`, `src/slic3r/GUI/Preferences.cpp`)
- Implement compact-density rendering behavior inside the custom notebook controls via `use_compact_tab_density()` and apply a `compact_factor` to button margins, separator thickness and minimum button height in `ButtonsListCtrl`. (file: `src/slic3r/GUI/Notebook.cpp`)

### Testing
- Ran repository checks with `git diff --check` to detect whitespace/patch issues and the check completed with no errors.
- Searched the codebase for integration markers with `rg -n "tab_density_compact|init_tabpanel\(|_USE_CUSTOM_NOTEBOOK"` to validate the changes are wired; the expected occurrences were found and the search completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a22434b2ac832da3c8075ee8293888)