### PR TITLE
Add reusable GUI spacing scale and UI density presets (ThemeMetrics)

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -178,6 +178,9 @@ void AppConfig::set_defaults()
         if (get("tab_density_compact").empty())
             set("tab_density_compact", "0");
 
+        if (get("ui_density").empty())
+            set("ui_density", get_bool("tab_density_compact") ? "compact" : "comfortable");
+
         if (get("font_size").empty())
             set("font_size", "0");
 

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -278,6 +278,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/DoubleSlider.hpp
     GUI/Notebook.cpp
     GUI/Notebook.hpp
+    GUI/ThemeMetrics.cpp
+    GUI/ThemeMetrics.hpp
     GUI/ObjectDataViewModel.cpp
     GUI/ObjectDataViewModel.hpp
     GUI/InstanceCheck.cpp

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -43,6 +43,7 @@
 #include "I18N.hpp"
 #include "NotificationManager.hpp"
 #include "format.hpp"
+#include "ThemeMetrics.hpp"
 
 #include "slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp"
 #include "slic3r/Utils/UndoRedo.hpp"
@@ -5751,9 +5752,9 @@ bool GLCanvas3D::_init_main_toolbar()
     m_main_toolbar.set_layout_type(GLToolbar::Layout::Horizontal);
     m_main_toolbar.set_horizontal_orientation(GLToolbar::Layout::HO_Right);
     m_main_toolbar.set_vertical_orientation(GLToolbar::Layout::VO_Top);
-    m_main_toolbar.set_border(5.0f);
-    m_main_toolbar.set_separator_size(5);
-    m_main_toolbar.set_gap_size(4);
+    m_main_toolbar.set_border(ThemeMetrics::toolbar_border());
+    m_main_toolbar.set_separator_size(ThemeMetrics::toolbar_separator());
+    m_main_toolbar.set_gap_size(ThemeMetrics::toolbar_main_gap());
 
     GLToolbarItem::Data item;
     int sprite_id = 0;
@@ -5978,9 +5979,9 @@ bool GLCanvas3D::_init_undoredo_toolbar()
     m_undoredo_toolbar.set_layout_type(GLToolbar::Layout::Horizontal);
     m_undoredo_toolbar.set_horizontal_orientation(GLToolbar::Layout::HO_Left);
     m_undoredo_toolbar.set_vertical_orientation(GLToolbar::Layout::VO_Top);
-    m_undoredo_toolbar.set_border(5.0f);
-    m_undoredo_toolbar.set_separator_size(5);
-    m_undoredo_toolbar.set_gap_size(4);
+    m_undoredo_toolbar.set_border(ThemeMetrics::toolbar_border());
+    m_undoredo_toolbar.set_separator_size(ThemeMetrics::toolbar_separator());
+    m_undoredo_toolbar.set_gap_size(ThemeMetrics::toolbar_main_gap());
 
     GLToolbarItem::Data item;
 

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -8,6 +8,7 @@
 
 #include "GUI_App.hpp"
 #include "GUI_Tags.hpp"
+#include "ThemeMetrics.hpp"
 #include "wxExtensions.hpp"
 
 #include <wx/button.h>
@@ -29,12 +30,6 @@ constexpr const char* ROLE_TAB_BORDER_FOCUS = "tab.border.focus";
 constexpr const char* ROLE_TAB_TEXT_DEFAULT = "tab.text.default";
 constexpr const char* ROLE_TAB_TEXT_HOVER = "tab.text.hover";
 constexpr const char* ROLE_TAB_TEXT_SELECTED = "tab.text.selected";
-
-bool use_compact_tab_density()
-{
-    auto *app_config = Slic3r::GUI::wxGetApp().app_config;
-    return app_config != nullptr && app_config->get_bool("tab_density_compact");
-}
 
 void draw_tab_chrome(wxDC& dc, const wxRect& button_rect, const wxRect& client_rect, const wxColour& background, const wxColour& border, const wxColour* focus_ring, int radius, int bottom_line_height)
 {
@@ -65,14 +60,8 @@ ButtonsListCtrl::ButtonsListCtrl(wxWindow *parent, bool add_mode_buttons/* = fal
     SetDoubleBuffered(true);
 #endif //__WINDOWS__
 
-    int em = em_unit(this);// Slic3r::GUI::wxGetApp().em_unit();
-    const double compact_factor = use_compact_tab_density() ? 0.75 : 1.0;
-#ifdef __WINDOWS__
-    m_btn_margin = std::lround(0.3 * em * compact_factor);
-#else
-    m_btn_margin = std::lround(0.4 * em * compact_factor);
-#endif
-    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
+    m_btn_margin = ThemeMetrics::notebook_button_margin(this);
+    m_line_margin = ThemeMetrics::notebook_line_margin(this);
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 
@@ -107,7 +96,7 @@ void ButtonsListCtrl::OnPaint(wxPaintEvent&)
     dc.Clear();
 
     const wxRect client_rect(wxPoint(0, 0), GetClientSize());
-    const int radius = std::max(2, m_btn_margin / 2);
+    const int radius = ThemeMetrics::radius_sm(this);
 
     for (int idx = 0; idx < int(m_pageButtons.size()); ++idx) {
         if (ScalableButton *button = m_pageButtons[idx]) {
@@ -180,17 +169,8 @@ void ButtonsListCtrl::UpdateMode()
 
 void ButtonsListCtrl::Rescale()
 {
-    int em = em_unit(this);
-    const double compact_factor = use_compact_tab_density() ? 0.75 : 1.0;
-
-#ifdef __APPLE__
-    // Adjust margins and sizes specifically for macOS
-    m_btn_margin = std::lround(0.4 * em * compact_factor);
-    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
-#else
-    m_btn_margin = std::lround(0.3 * em * compact_factor);
-    m_line_margin = std::max(1, std::lround(0.1 * em * compact_factor));
-#endif //__APPLE__
+    m_btn_margin = ThemeMetrics::notebook_button_margin(this);
+    m_line_margin = ThemeMetrics::notebook_line_margin(this);
 
     m_buttons_sizer->SetVGap(m_btn_margin);  // Adjust vertical gap here
     m_buttons_sizer->SetHGap(m_btn_margin);  // Adjust horizontal gap here
@@ -238,8 +218,8 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString& text, bool bSelect/* 
 #endif //__APPLE__
         false, bmp_size);
 
-    if (use_compact_tab_density())
-        btn->SetMinSize(wxSize(-1, std::lround(1.8 * em_unit(this))));
+    if (ThemeMetrics::ui_density_preference() == "compact")
+        btn->SetMinSize(wxSize(-1, ThemeMetrics::notebook_min_height(this)));
 
     apply_tab_state(btn, bSelect ? TabVisualState::Selected : TabVisualState::Default);
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -18,6 +18,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "Plater.hpp"
+#include "ThemeMetrics.hpp"
 #include "slic3r/GUI/Jobs/UIThreadWorker.hpp"
 
 #include <cstddef>
@@ -5065,8 +5066,8 @@ bool Plater::priv::init_view_toolbar()
 
     view_toolbar.set_horizontal_orientation(GLToolbar::Layout::HO_Left);
     view_toolbar.set_vertical_orientation(GLToolbar::Layout::VO_Bottom);
-    view_toolbar.set_border(5.0f);
-    view_toolbar.set_gap_size(1.0f);
+    view_toolbar.set_border(ThemeMetrics::toolbar_border());
+    view_toolbar.set_gap_size(ThemeMetrics::toolbar_view_gap());
 
     GLToolbarItem::Data item;
 
@@ -5113,9 +5114,9 @@ bool Plater::priv::init_collapse_toolbar()
     collapse_toolbar.set_layout_type(GLToolbar::Layout::Vertical);
     collapse_toolbar.set_horizontal_orientation(GLToolbar::Layout::HO_Right);
     collapse_toolbar.set_vertical_orientation(GLToolbar::Layout::VO_Top);
-    collapse_toolbar.set_border(5.0f);
-    collapse_toolbar.set_separator_size(5);
-    collapse_toolbar.set_gap_size(2);
+    collapse_toolbar.set_border(ThemeMetrics::toolbar_border());
+    collapse_toolbar.set_separator_size(ThemeMetrics::toolbar_separator());
+    collapse_toolbar.set_gap_size(ThemeMetrics::toolbar_collapse_gap());
 
     GLToolbarItem::Data item;
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -100,6 +100,16 @@ namespace Slic3r {
     };
     CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SuppressHyperlinks)
 
+    enum UiDensityMode {
+        uiDensityComfortable,
+        uiDensityCompact,
+    };
+    static const t_config_enum_values s_keys_map_UiDensityMode = {
+        {"comfortable", uiDensityComfortable},
+        {"compact", uiDensityCompact},
+    };
+    CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(UiDensityMode)
+
 namespace GUI {
 
 wxIcon icon_from_bitmap(const wxBitmap &bitmap) {
@@ -186,6 +196,7 @@ void PreferencesDialog::show(const std::string& highlight_opt_key /*= std::strin
             {"notify_release", s_keys_map_NotifyReleaseMode},
             {"auto_switch_preview", s_keys_map_AutoSwitchPreview},
             {"suppress_hyperlinks", s_keys_map_SuppressHyperlinks},
+            {"ui_density", s_keys_map_UiDensityMode},
         };
         for (auto key2map : enums) {
             if (m_optkey_to_optgroup.find(key2map.first) != m_optkey_to_optgroup.end()) {
@@ -975,11 +986,16 @@ void PreferencesDialog::build()
 			app_config->get_int("tab_icon_size"));
 		m_values_need_restart.push_back("tab_icon_size");
 
-		append_bool_option(m_tabid_2_optgroups.back().back(), "tab_density_compact",
-			L("Use compact tab density"),
-			L("Reduce tab button paddings to better fit laptop-sized displays. Disable for roomier tab spacing on larger screens."),
-			app_config->get_bool("tab_density_compact"));
-		m_values_need_restart.push_back("tab_density_compact");
+		std::string ui_density_value = app_config->get("ui_density");
+		if (s_keys_map_UiDensityMode.find(ui_density_value) == s_keys_map_UiDensityMode.end())
+			ui_density_value = app_config->get_bool("tab_density_compact") ? "compact" : "comfortable";
+		append_enum_option<UiDensityMode>(m_tabid_2_optgroups.back().back(), "ui_density",
+			L("UI density"),
+			L("Controls spacing across tabs, toolbars, and combo boxes. Compact fits more UI on screen; Comfortable provides roomier spacing."),
+			new ConfigOptionEnum<UiDensityMode>(static_cast<UiDensityMode>(s_keys_map_UiDensityMode.at(ui_density_value))),
+			{ { "comfortable", L("Comfortable") },
+			  { "compact", L("Compact") } });
+		m_values_need_restart.push_back("ui_density");
 		
 		append_int_option(m_tabid_2_optgroups.back().back(), "font_size",
 			L("Font size"),

--- a/src/slic3r/GUI/ThemeMetrics.cpp
+++ b/src/slic3r/GUI/ThemeMetrics.cpp
@@ -1,0 +1,132 @@
+#include "ThemeMetrics.hpp"
+
+#include "GUI_App.hpp"
+#include "wxExtensions.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace Slic3r::GUI::ThemeMetrics {
+
+namespace {
+enum class Platform : size_t { Windows = 0, Mac = 1, Linux = 2 };
+enum class Density : size_t { Comfortable = 0, Compact = 1 };
+
+struct TokenTable {
+    double space_xs_em;
+    double space_sm_em;
+    double space_md_em;
+    double space_lg_em;
+
+    double radius_sm_em;
+    double radius_md_em;
+    double stroke_thin_em;
+
+    double notebook_btn_margin_em;
+    double notebook_line_margin_em;
+    double notebook_min_height_em;
+
+    float toolbar_border_px;
+    float toolbar_separator_px;
+    float toolbar_main_gap_px;
+    float toolbar_view_gap_px;
+    float toolbar_collapse_gap_px;
+};
+
+constexpr std::array<std::array<TokenTable, 2>, 3> TOKEN_TABLE = {{
+    // Windows
+    {{
+        {0.10, 0.20, 0.30, 0.40, 0.20, 0.30, 0.10, 0.30, 0.10, 2.40, 5.0f, 5.0f, 4.0f, 1.0f, 2.0f},
+        {0.08, 0.15, 0.23, 0.30, 0.16, 0.24, 0.08, 0.23, 0.08, 1.80, 4.0f, 4.0f, 3.0f, 1.0f, 1.0f}
+    }},
+    // macOS
+    {{
+        {0.12, 0.24, 0.40, 0.50, 0.22, 0.34, 0.10, 0.40, 0.10, 2.40, 5.0f, 5.0f, 4.0f, 1.0f, 2.0f},
+        {0.09, 0.18, 0.30, 0.38, 0.17, 0.26, 0.08, 0.30, 0.08, 1.80, 4.0f, 4.0f, 3.0f, 1.0f, 1.0f}
+    }},
+    // Linux and others
+    {{
+        {0.12, 0.24, 0.40, 0.50, 0.22, 0.34, 0.10, 0.40, 0.10, 2.40, 5.0f, 5.0f, 4.0f, 1.0f, 2.0f},
+        {0.09, 0.18, 0.30, 0.38, 0.17, 0.26, 0.08, 0.30, 0.08, 1.80, 4.0f, 4.0f, 3.0f, 1.0f, 1.0f}
+    }}
+}};
+
+Platform current_platform()
+{
+#ifdef _WIN32
+    return Platform::Windows;
+#elif defined(__APPLE__)
+    return Platform::Mac;
+#else
+    return Platform::Linux;
+#endif
+}
+
+Density current_density()
+{
+    const std::string pref = ui_density_preference();
+    return pref == "compact" ? Density::Compact : Density::Comfortable;
+}
+
+const TokenTable& table()
+{
+    return TOKEN_TABLE[static_cast<size_t>(current_platform())][static_cast<size_t>(current_density())];
+}
+
+int em_scaled(wxWindow* win, double ems)
+{
+    const int em = em_unit(win);
+    return std::lround(ems * em);
+}
+
+int em_scaled_min1(wxWindow* win, double ems)
+{
+    return std::max(1, em_scaled(win, ems));
+}
+
+} // namespace
+
+std::string ui_density_preference()
+{
+    auto* app_config = wxGetApp().app_config;
+    if (app_config == nullptr)
+        return "comfortable";
+
+    const std::string density = app_config->get("ui_density");
+    if (density == "compact" || density == "comfortable")
+        return density;
+
+    return app_config->get_bool("tab_density_compact") ? "compact" : "comfortable";
+}
+
+int space_xs(wxWindow* win) { return em_scaled_min1(win, table().space_xs_em); }
+int space_sm(wxWindow* win) { return em_scaled_min1(win, table().space_sm_em); }
+int space_md(wxWindow* win) { return em_scaled_min1(win, table().space_md_em); }
+int space_lg(wxWindow* win) { return em_scaled_min1(win, table().space_lg_em); }
+
+int radius_sm(wxWindow* win) { return em_scaled_min1(win, table().radius_sm_em); }
+int radius_md(wxWindow* win) { return em_scaled_min1(win, table().radius_md_em); }
+int stroke_thin(wxWindow* win) { return em_scaled_min1(win, table().stroke_thin_em); }
+
+int notebook_button_margin(wxWindow* win) { return em_scaled_min1(win, table().notebook_btn_margin_em); }
+int notebook_line_margin(wxWindow* win) { return em_scaled_min1(win, table().notebook_line_margin_em); }
+int notebook_min_height(wxWindow* win) { return em_scaled_min1(win, table().notebook_min_height_em); }
+
+float toolbar_border() { return table().toolbar_border_px; }
+float toolbar_separator() { return table().toolbar_separator_px; }
+float toolbar_main_gap() { return table().toolbar_main_gap_px; }
+float toolbar_view_gap() { return table().toolbar_view_gap_px; }
+float toolbar_collapse_gap() { return table().toolbar_collapse_gap_px; }
+
+double combo_corner_radius(wxWindow* win)
+{
+    return wxGetApp().suppress_round_corners() ? 0.0 : static_cast<double>(radius_md(win));
+}
+
+int combo_item_padding(wxWindow* win)
+{
+    return space_xs(win);
+}
+
+} // namespace Slic3r::GUI::ThemeMetrics

--- a/src/slic3r/GUI/ThemeMetrics.hpp
+++ b/src/slic3r/GUI/ThemeMetrics.hpp
@@ -1,0 +1,36 @@
+#ifndef slic3r_GUI_ThemeMetrics_hpp_
+#define slic3r_GUI_ThemeMetrics_hpp_
+
+#include <string>
+
+class wxWindow;
+
+namespace Slic3r::GUI::ThemeMetrics {
+
+int space_xs(wxWindow* win);
+int space_sm(wxWindow* win);
+int space_md(wxWindow* win);
+int space_lg(wxWindow* win);
+
+int radius_sm(wxWindow* win);
+int radius_md(wxWindow* win);
+int stroke_thin(wxWindow* win);
+
+int notebook_button_margin(wxWindow* win);
+int notebook_line_margin(wxWindow* win);
+int notebook_min_height(wxWindow* win);
+
+float toolbar_border();
+float toolbar_separator();
+float toolbar_main_gap();
+float toolbar_view_gap();
+float toolbar_collapse_gap();
+
+double combo_corner_radius(wxWindow* win);
+int combo_item_padding(wxWindow* win);
+
+std::string ui_density_preference();
+
+} // namespace Slic3r::GUI::ThemeMetrics
+
+#endif

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -1,6 +1,7 @@
 #include "DropDown.hpp"
 #include "ComboBox.hpp"
 #include "../GUI_App.hpp"
+#include "../ThemeMetrics.hpp"
 #include "../OptionsGroup.hpp"
 
 #include <wx/dcgraph.h>
@@ -41,7 +42,7 @@ DropDown::DropDown(std::vector<wxString> &texts,
                    std::vector<wxBitmapBundle> &icons)
     : texts(texts)
     , icons(icons)
-    , radius(Slic3r::GUI::wxGetApp().suppress_round_corners() ? 0 : 5)
+    , radius(0.0)
     , state_handler(this)
     , text_color(0x363636)
     , border_color(0xDBDBDB)
@@ -123,6 +124,7 @@ void DropDown::Create(wxWindow *     parent,
     text_off = style & DD_NO_TEXT;
 
     SetFont(parent->GetFont());
+    radius = Slic3r::GUI::ThemeMetrics::combo_corner_radius(parent);
 #ifdef __WXOSX__
     // wxPopupTransientWindow releases mouse on idle, which may cause various problems,
     //  such as losting mouse move, and dismissing soon on first LEFT_DOWN event.
@@ -209,6 +211,7 @@ void DropDown::SetAlignIcon(bool align) { align_icon = align; }
 
 void DropDown::Rescale()
 {
+    radius = Slic3r::GUI::ThemeMetrics::combo_corner_radius(GetParent() ? GetParent() : this);
     need_sync = true;
 }
 
@@ -270,7 +273,6 @@ constexpr int slider_step   = 1;
 #else
 constexpr int slider_step   = 5;
 #endif
-constexpr int items_padding = 2;
 
 /*
  * Here we do the actual rendering. I put it in a separate
@@ -444,7 +446,7 @@ void DropDown::messureSize()
     }
     if (iconSize.x > 0) szContent.x += iconSize.x + (text_off ? 0 : 5);
     if (iconSize.y > szContent.y) szContent.y = iconSize.y;
-    szContent.y += items_padding;
+    szContent.y += Slic3r::GUI::ThemeMetrics::combo_item_padding(GetParent() ? GetParent() : this);
     if (texts.size() > 15) szContent.x += 6;
     if (GetParent()) {
         auto x = GetParent()->GetSize().x;


### PR DESCRIPTION
### Motivation
- Centralize GUI spacing/radius/stroke tokens and provide platform/density overrides so spacing is consistent and not scattered as per-file `#ifdef` magic numbers. 
- Make notebook/tab/button/toolbar/combo spacing configurable and expose a quick `comfortable / compact` density preference to modernize UI spacing without rewriting controls.

### Description
- Add `Slic3r::GUI::ThemeMetrics` helper with platform- and density-aware token tables and APIs like `space.xs/sm/md/lg`, `radius.sm/md`, `stroke.thin`, `notebook_button_margin`, `notebook_line_margin`, `notebook_min_height`, `toolbar_*`, `combo_corner_radius`, and `combo_item_padding` (`src/slic3r/GUI/ThemeMetrics.hpp` / `ThemeMetrics.cpp`).
- Replace ad-hoc notebook tab spacing and magic multipliers with token lookups in `ButtonsListCtrl` constructor, `Rescale()` and `InsertPage` so `m_btn_margin`, `m_line_margin`, tab radius and compact min-height come from `ThemeMetrics` (`src/slic3r/GUI/Notebook.cpp`).
- Switch top toolbar layout constants (border / separator / gap) to `ThemeMetrics` in `GLCanvas3D` and `Plater` so toolbar sizing uses centralized tokens (`src/slic3r/GUI/GLCanvas3D.cpp`, `src/slic3r/GUI/Plater.cpp`).
- Make combo/dropdown use tokenized corner radius and item padding and update rescale behavior, add a `UiDensityMode` preference (`comfortable` / `compact`) in Preferences and provide a backward-compatible default migration from `tab_density_compact` in `AppConfig`, and add the new files to the build (`src/slic3r/GUI/Widgets/DropDown.cpp`, `src/slic3r/GUI/Preferences.cpp`, `src/libslic3r/AppConfig.cpp`, `src/slic3r/CMakeLists.txt`).

### Testing
- Ran CMake configure (`cmake -S . -B build -G Ninja`) to validate integration wiring; configuration progressed but stopped due to a missing system DBus development package in the environment, so a full build was not completed. 
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2250b02b8832d984fd742532740c2)