### PR TITLE
Refactor ThemeMetrics namespace and qualify callers; fix AppConfig access

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -14,8 +14,6 @@
 #include "GUI_ObjectManipulation.hpp"
 #include "GUI_Factories.hpp"
 #include "format.hpp"
-#include "InstanceCheck.hpp" 
-
 // Localization headers: include libslic3r version first so everything in this file
 // uses the slic3r/GUI version (the macros will take precedence over the functions).
 // Also, there is a check that the former is not included from slic3r module.
@@ -123,9 +121,6 @@
 #ifdef _MSW_DARK_MODE
 #include <wx/msw/dark_mode.h>
 #endif // _MSW_DARK_MODE
-#endif
-#ifdef _WIN32
-#include <boost/dll/runtime_symbol_info.hpp>
 #endif
 
 #if ENABLE_THUMBNAIL_GENERATOR_DEBUG
@@ -2129,7 +2124,7 @@ const wxColour& GUI_App::get_style_role_color(const std::string& role) const
     if (role == "combo.bg.disabled") {
 #ifdef _MSW_DARK_MODE
         if (dark_mode()) {
-            static const wxColour disabled_dark = wxRGBToColour(NppDarkMode::GetSofterBackgroundColor());
+            static const wxColour disabled_dark(NppDarkMode::GetSofterBackgroundColor());
             return disabled_dark;
         }
 #endif

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -60,8 +60,8 @@ ButtonsListCtrl::ButtonsListCtrl(wxWindow *parent, bool add_mode_buttons/* = fal
     SetDoubleBuffered(true);
 #endif //__WINDOWS__
 
-    m_btn_margin = ThemeMetrics::notebook_button_margin(this);
-    m_line_margin = ThemeMetrics::notebook_line_margin(this);
+    m_btn_margin = Slic3r::GUI::ThemeMetrics::notebook_button_margin(this);
+    m_line_margin = Slic3r::GUI::ThemeMetrics::notebook_line_margin(this);
 
     SetBackgroundStyle(wxBG_STYLE_PAINT);
 
@@ -96,7 +96,7 @@ void ButtonsListCtrl::OnPaint(wxPaintEvent&)
     dc.Clear();
 
     const wxRect client_rect(wxPoint(0, 0), GetClientSize());
-    const int radius = ThemeMetrics::radius_sm(this);
+    const int radius = Slic3r::GUI::ThemeMetrics::radius_sm(this);
 
     for (int idx = 0; idx < int(m_pageButtons.size()); ++idx) {
         if (ScalableButton *button = m_pageButtons[idx]) {
@@ -169,8 +169,8 @@ void ButtonsListCtrl::UpdateMode()
 
 void ButtonsListCtrl::Rescale()
 {
-    m_btn_margin = ThemeMetrics::notebook_button_margin(this);
-    m_line_margin = ThemeMetrics::notebook_line_margin(this);
+    m_btn_margin = Slic3r::GUI::ThemeMetrics::notebook_button_margin(this);
+    m_line_margin = Slic3r::GUI::ThemeMetrics::notebook_line_margin(this);
 
     m_buttons_sizer->SetVGap(m_btn_margin);  // Adjust vertical gap here
     m_buttons_sizer->SetHGap(m_btn_margin);  // Adjust horizontal gap here
@@ -218,8 +218,8 @@ bool ButtonsListCtrl::InsertPage(size_t n, const wxString& text, bool bSelect/* 
 #endif //__APPLE__
         false, bmp_size);
 
-    if (ThemeMetrics::ui_density_preference() == "compact")
-        btn->SetMinSize(wxSize(-1, ThemeMetrics::notebook_min_height(this)));
+    if (Slic3r::GUI::ThemeMetrics::ui_density_preference() == "compact")
+        btn->SetMinSize(wxSize(-1, Slic3r::GUI::ThemeMetrics::notebook_min_height(this)));
 
     apply_tab_state(btn, bSelect ? TabVisualState::Selected : TabVisualState::Default);
 

--- a/src/slic3r/GUI/ThemeMetrics.cpp
+++ b/src/slic3r/GUI/ThemeMetrics.cpp
@@ -1,13 +1,16 @@
 #include "ThemeMetrics.hpp"
 
 #include "GUI_App.hpp"
+#include "libslic3r/AppConfig.hpp"
 #include "wxExtensions.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cmath>
 
-namespace Slic3r::GUI::ThemeMetrics {
+namespace Slic3r {
+namespace GUI {
+namespace ThemeMetrics {
 
 namespace {
 enum class Platform : size_t { Windows = 0, Mac = 1, Linux = 2 };
@@ -89,7 +92,7 @@ int em_scaled_min1(wxWindow* win, double ems)
 
 std::string ui_density_preference()
 {
-    auto* app_config = wxGetApp().app_config;
+    AppConfig* app_config = wxGetApp().app_config.get();
     if (app_config == nullptr)
         return "comfortable";
 
@@ -129,4 +132,6 @@ int combo_item_padding(wxWindow* win)
     return space_xs(win);
 }
 
-} // namespace Slic3r::GUI::ThemeMetrics
+} // namespace ThemeMetrics
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/GUI/ThemeMetrics.hpp
+++ b/src/slic3r/GUI/ThemeMetrics.hpp
@@ -5,7 +5,9 @@
 
 class wxWindow;
 
-namespace Slic3r::GUI::ThemeMetrics {
+namespace Slic3r {
+namespace GUI {
+namespace ThemeMetrics {
 
 int space_xs(wxWindow* win);
 int space_sm(wxWindow* win);
@@ -31,6 +33,8 @@ int combo_item_padding(wxWindow* win);
 
 std::string ui_density_preference();
 
-} // namespace Slic3r::GUI::ThemeMetrics
+} // namespace ThemeMetrics
+} // namespace GUI
+} // namespace Slic3r
 
 #endif


### PR DESCRIPTION
### Motivation
- Standardize the `ThemeMetrics` namespace layout and make its APIs explicitly addressable from other GUI modules.
- Ensure reliable access to the global `app_config` instance when resolving UI density preferences.

### Description
- Replace the inline namespace declaration `namespace Slic3r::GUI::ThemeMetrics {` with nested `namespace Slic3r { namespace GUI { namespace ThemeMetrics {` in `ThemeMetrics.hpp` and `ThemeMetrics.cpp`.
- Add `#include "libslic3r/AppConfig.hpp"` and change `ui_density_preference()` to obtain the config pointer via `wxGetApp().app_config.get()`.
- Update call sites in `Notebook.cpp` to fully qualify ThemeMetrics symbols (for example `Slic3r::GUI::ThemeMetrics::notebook_button_margin`).
- Minor cleanups: construct `wxColour` directly in `GUI_App.cpp` and remove a duplicated/unused include block for `runtime_symbol_info`/`InstanceCheck`.

### Testing
- Performed a full project build in CI environments and the compilation completed successfully.
- Ran the repository's automated test suite where available and all reported tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a22f45b904832da908983b9b3af71b)