### PR TITLE
Harden WM_INPUT raw input read handling

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -790,12 +790,16 @@ static void register_win32_device_notification_event()
         auto plater = (main_frame == nullptr) ? nullptr : main_frame->plater();
 //        if (wParam == RIM_INPUTSINK && plater != nullptr && main_frame->IsActive()) {
         if (wParam == RIM_INPUT && plater != nullptr && main_frame->IsActive()) {
-        RAWINPUT raw;
-			UINT rawSize = sizeof(RAWINPUT);
-			::GetRawInputData((HRAWINPUT)lParam, RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
-			if (raw.header.dwType == RIM_TYPEHID && plater->get_mouse3d_controller().handle_raw_input_win32(raw.data.hid.bRawData, raw.data.hid.dwSizeHid))
-				return true;
-		}
+            RAWINPUT raw{};
+            UINT     rawSize = sizeof(raw);
+            const UINT bytes_read = ::GetRawInputData((HRAWINPUT)lParam, RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
+            if (bytes_read == static_cast<UINT>(-1) || bytes_read < sizeof(RAWINPUTHEADER) || rawSize < sizeof(RAWINPUTHEADER))
+                return false;
+
+            if (raw.header.dwType == RIM_TYPEHID &&
+                plater->get_mouse3d_controller().handle_raw_input_win32(raw.data.hid.bRawData, raw.data.hid.dwSizeHid))
+                return true;
+        }
         return false;
     });
 


### PR DESCRIPTION
### Motivation
- Avoid inspecting uninitialized or partially-read `RAWINPUT` data in the `WM_INPUT` message handler and make error cases explicit so static analysis and runtime behavior are safer.

### Description
- Replace `RAWINPUT raw;` with zero-initialized `RAWINPUT raw{}` and initialize `rawSize` from `sizeof(raw)`.
- Capture `GetRawInputData(...)` return into `bytes_read` and validate that it is not `UINT(-1)` and that both `bytes_read` and `rawSize` are at least `sizeof(RAWINPUTHEADER)` before accessing `raw.header.dwType`.
- Only call `handle_raw_input_win32(...)` when the read succeeded and `raw.header.dwType == RIM_TYPEHID`, and return `false` early on invalid/failed reads.

### Testing
- Verified changes with `git diff -- src/slic3r/GUI/GUI_App.cpp` and inspected the patched region via `nl -ba src/slic3r/GUI/GUI_App.cpp | sed -n '786,812p'`; no automated build/test was run for this targeted handler safety fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23356253c832db0bee9cd4bb3bf43)