### PR TITLE
Add minimal cpp.hint for Visual Studio IntelliSense in GUI_App.cpp

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -1,0 +1,29 @@
+// Visual Studio IntelliSense hint file.
+//
+// Purpose:
+// - Provide a minimal set of preprocessor symbols so IntelliSense can follow
+//   the common code paths in src/slic3r/GUI/GUI_App.cpp.
+// - This helps reduce repeated VCR102 diagnostics caused by unresolved
+//   platform / feature-gated branches while browsing.
+//
+// Usage for contributors:
+// - Keep this file small and focused on frequently-hit gates.
+// - After changing this file, reopen the solution (or refresh IntelliSense)
+//   so the database is rebuilt with updated symbols.
+
+// Primary platform gates used across GUI_App.cpp
+#define _WIN32
+#define WIN32
+#define __linux__
+#define __APPLE__
+
+// wxWidgets / platform integration gates
+#define __WXMSW__
+#define __WXGTK3__
+
+// SuperSlicer feature gates frequently encountered in GUI_App.cpp
+#define _MSW_DARK_MODE
+#define USE_GTHUB_PRESET_UPDATE
+#define ENABLE_GL_CORE_PROFILE
+#define ENABLE_THUMBNAIL_GENERATOR_DEBUG
+#define GUI_TAG_PALETTE


### PR DESCRIPTION
### Motivation
- Reduce repeated VCR102 IntelliSense noise when browsing `src/slic3r/GUI/GUI_App.cpp` by providing a small set of commonly-hit platform and feature macros so the database follows major gated code paths.

### Description
- Add a new repository-root `cpp.hint` file that documents usage and defines a minimal set of platform and project feature macros (for example `_WIN32`, `WIN32`, `__linux__`, `__APPLE__`, `__WXMSW__`, `_MSW_DARK_MODE`, `USE_GTHUB_PRESET_UPDATE`, `ENABLE_GL_CORE_PROFILE`, `ENABLE_THUMBNAIL_GENERATOR_DEBUG`, and `GUI_TAG_PALETTE`).

### Testing
- Ran local verification commands `rg -n "#if|#ifdef|#ifndef|defined(\(" src/slic3r/GUI/GUI_App.cpp`, `nl -ba cpp.hint`, `git status --short`, and committed the new file successfully, and note that rebuilding the Visual Studio IntelliSense DB (e.g. via `devenv <solution>.sln`) must be performed on a contributor Windows machine to confirm VCR102 reduction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a236909440832d95c38f1ce66c90ef)